### PR TITLE
Prevent R# warnings about wrong namespaces

### DIFF
--- a/src/StructAnalyzers/StructAnalyzers/StructAnalyzers.csproj
+++ b/src/StructAnalyzers/StructAnalyzers/StructAnalyzers.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard1.3</TargetFramework>
+    <RootNamespace>ErrorProne.NET.Structs</RootNamespace>
     <IncludeBuildOutput>true</IncludeBuildOutput>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>


### PR DESCRIPTION
Placed ErrorProne.NET.Structs as root namespace for StructAnalyzer