### PR TITLE
Remove empty tests

### DIFF
--- a/src/ErrorProne.NET.StructAnalyzers.Tests/DefaultEqualsOrHashCodeIsUsedInStructAnalyzerTests.cs
+++ b/src/ErrorProne.NET.StructAnalyzers.Tests/DefaultEqualsOrHashCodeIsUsedInStructAnalyzerTests.cs
@@ -51,16 +51,5 @@ struct AnotherStruct : System.IEquatable<AnotherStruct>
 }
 ";
         }
-        
-        [TestCaseSource(nameof(GetNoDiagnosticCases))]
-        public async Task NoDiagnosticCases(string code)
-        {
-            await VerifyCS.VerifyAnalyzerAsync(code);
-        }
-
-        public static IEnumerable<string> GetNoDiagnosticCases()
-        {
-            yield break;
-        }
     }
 }

--- a/src/ErrorProne.NET.StructAnalyzers.Tests/NonReadOnlyStructRefReadOnlyLocalAnalyzerTests.cs
+++ b/src/ErrorProne.NET.StructAnalyzers.Tests/NonReadOnlyStructRefReadOnlyLocalAnalyzerTests.cs
@@ -1,6 +1,5 @@
 ﻿using ErrorProne.NET.TestHelpers;
 using NUnit.Framework;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using VerifyCS = ErrorProne.NET.TestHelpers.CSharpCodeFixVerifier<
     ErrorProne.NET.StructAnalyzers.NonReadOnlyStructRefReadOnlyLocalAnalyzer,
@@ -19,28 +18,6 @@ namespace ErrorProne.NET.StructAnalyzers.Tests
             {
                 TestState = { Sources = { code } },
             }.WithoutGeneratedCodeVerification().RunAsync();
-        }
-
-        [TestCaseSource(nameof(GetHasDiagnosticsTestCases))]
-        public async Task HasDiagnosticsTestCases(string code)
-        {
-            await VerifyCS.VerifyAnalyzerAsync(code);
-        }
-
-        public static IEnumerable<string> GetHasDiagnosticsTestCases()
-        {
-            yield break;
-        }
-
-        [TestCaseSource(nameof(GetNoDiagnosticsTestCases))]
-        public async Task NoDiagnosticsTestCases(string code)
-        {
-            await VerifyCS.VerifyAnalyzerAsync(code);
-        }
-
-        public static IEnumerable<string> GetNoDiagnosticsTestCases()
-        {
-            yield break;
         }
     }
 }


### PR DESCRIPTION
Empty test cases prevent Test Explorer in Visual Studio from running all tests in the project.