### PR TITLE
Move analyzer into StructsAnalyzers and make it stricter

### DIFF
--- a/src/ErrorProne.NET.CoreAnalyzers/AnalyzerReleases.Unshipped.md
+++ b/src/ErrorProne.NET.CoreAnalyzers/AnalyzerReleases.Unshipped.md
@@ -13,5 +13,3 @@ EPC16 | CodeSmell | Warning | NullConditionalOperatorAnalyzer
 ERP021 | CodeSmell | Warning | ThrowExAnalyzer
 ERP022 | CodeSmell | Warning | SwallowAllExceptionsAnalyzer
 ERP031 | Concurrency | Warning | ConcurrentCollectionAnalyzer
-ERP041 | CodeSmell | Warning | DoNotCreateStructWithNoDefaultStructConstructionAttributeAnalyzer
-ERP042 | CodeSmell | Warning | DoNotEmbedStructsWithNoDefaultStructConstructionAttributeAnalyzer

--- a/src/ErrorProne.NET.CoreAnalyzers/DiagnosticIds.cs
+++ b/src/ErrorProne.NET.CoreAnalyzers/DiagnosticIds.cs
@@ -31,9 +31,5 @@
 
         // Concurrency
         public const string UsageIsNotThreadSafe = "ERP031";
-
-        // Other analyzers
-        public const string DoNotUseDefaultConstructionForStruct = "ERP041";
-        public const string DoNotEmbedStructsMarkedWithDoUseDefaultConstructionForStruct = "ERP042";
     }
 }

--- a/src/ErrorProne.NET.StructAnalyzers/AnalyzerReleases.Unshipped.md
+++ b/src/ErrorProne.NET.StructAnalyzers/AnalyzerReleases.Unshipped.md
@@ -12,4 +12,6 @@ EPS05 | Performance | Warning | UseInModifierForReadOnlyStructAnalyzer
 EPS06 | Performance | Warning | HiddenStructCopyAnalyzer
 EPS07 | Performance | Warning | HashTableIncompatibilityAnalyzer
 EPS08 | Performance | Warning | DefaultEqualsOrHashCodeIsUsedInStructAnalyzer
-EPS09 | Usage | Warning | ExplicitInParameterAnalyzer
+EPS09 | Usage | Info | ExplicitInParameterAnalyzer
+EPS10 | CodeSmell | Warning | DoNotCreateStructWithNoDefaultStructConstructionAttributeAnalyzer
+EPS11 | CodeSmell | Warning | DoNotEmbedStructsWithNoDefaultStructConstructionAttributeAnalyzer

--- a/src/ErrorProne.NET.StructAnalyzers/DiagnosticIds.cs
+++ b/src/ErrorProne.NET.StructAnalyzers/DiagnosticIds.cs
@@ -31,5 +31,12 @@
 
         /// <nodoc />
         public const string ExplicitInParameterDiagnosticId = "EPS09";
+
+        /// <nodoc />
+        public const string DoNotUseDefaultConstructionForStruct = "EPS10";
+
+        /// <nodoc />
+        public const string DoNotEmbedStructsMarkedWithDoUseDefaultConstructionForStruct = "EPS11";
+
     }
 }

--- a/src/ErrorProne.NET.StructAnalyzers/NonDefaultStructs/DefaultStructConstructionAnalyzerBase.cs
+++ b/src/ErrorProne.NET.StructAnalyzers/NonDefaultStructs/DefaultStructConstructionAnalyzerBase.cs
@@ -3,9 +3,10 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using ErrorProne.NET.Core;
+using ErrorProne.NET.CoreAnalyzers;
 using Microsoft.CodeAnalysis;
 
-namespace ErrorProne.NET.CoreAnalyzers.NonDefaultStructs
+namespace ErrorProne.Net.StructAnalyzers.NonDefaultStructs
 {
     /// <summary>
     /// A base class for analyzing structs marked with <seealso cref="DoNotUseDefaultConstructionAttributeName"/>.

--- a/src/ErrorProne.NET.StructAnalyzers/NonDefaultStructs/DoNotCreateStructWithNoDefaultStructConstructionAttributeAnalyzer.cs
+++ b/src/ErrorProne.NET.StructAnalyzers/NonDefaultStructs/DoNotCreateStructWithNoDefaultStructConstructionAttributeAnalyzer.cs
@@ -1,8 +1,9 @@
-﻿using Microsoft.CodeAnalysis;
+﻿using ErrorProne.NET.StructAnalyzers;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
 
-namespace ErrorProne.NET.CoreAnalyzers.NonDefaultStructs
+namespace ErrorProne.Net.StructAnalyzers.NonDefaultStructs
 {
     /// <summary>
     /// An analyzer warns when a struct with non-default invariants is constructed via default construction.
@@ -44,6 +45,37 @@ namespace ErrorProne.NET.CoreAnalyzers.NonDefaultStructs
         {
             context.RegisterOperationAction(AnalyzeObjectCreation, OperationKind.ObjectCreation);
             context.RegisterOperationAction(AnalyzeDefaultValue, OperationKind.DefaultValue);
+            context.RegisterOperationAction(AnalyzeMethodInvocation, OperationKind.Invocation);
+        }
+
+        private void AnalyzeMethodInvocation(OperationAnalysisContext context)
+        {
+            var operation = (IInvocationOperation) context.Operation;
+            
+            // Searching for cases like Create<MyStruct>() when the generic has new T() constraint.
+            if (operation.TargetMethod.IsGenericMethod)
+            {
+                var constructedFrom = operation.TargetMethod.ConstructedFrom;
+
+                // Need to find only when the return type has new T() constraint.
+                if (constructedFrom.ReturnType.TypeKind == TypeKind.TypeParameter &&
+                    constructedFrom.ReturnType is ITypeParameterSymbol tps && tps.HasConstructorConstraint)
+                {
+                    ReportDiagnosticForTypeIfNeeded(context.Compilation, operation.Syntax, operation.TargetMethod.ReturnType, Rule, context.ReportDiagnostic);
+                }
+
+                // Another case: out or ref parameters with new T() constraint.
+                foreach (var p in operation.TargetMethod.Parameters)
+                {
+                    if (p.OriginalDefinition.Type.TypeKind == TypeKind.TypeParameter
+                        && (p.OriginalDefinition.RefKind == RefKind.Out || p.OriginalDefinition.RefKind == RefKind.Ref))
+                    {
+                        // Need to warn even without 'new T()' constraint, because a method can modify the argument by
+                        // doing 't = default;'
+                        ReportDiagnosticForTypeIfNeeded(context.Compilation, operation.Syntax, p.Type, Rule, context.ReportDiagnostic);
+                    }
+                }
+            }
         }
 
         private void AnalyzeDefaultValue(OperationAnalysisContext context)

--- a/src/ErrorProne.NET.StructAnalyzers/NonDefaultStructs/DoNotCreateStructWithNoDefaultStructConstructionAttributeAnalyzer.cs
+++ b/src/ErrorProne.NET.StructAnalyzers/NonDefaultStructs/DoNotCreateStructWithNoDefaultStructConstructionAttributeAnalyzer.cs
@@ -9,10 +9,6 @@ namespace ErrorProne.Net.StructAnalyzers.NonDefaultStructs
     /// An analyzer warns when a struct with non-default invariants is constructed via default construction.
     /// For instance <code>ImmutableArray&lt;int&gt; a = default; int x = a.Count; will fail with NRE.</code>
     /// </summary>
-    /// <remarks>
-    /// Technically this analyzer belongs to StructAnalyzers project, but because its more important
-    /// and a bit more common, I decided to put it into the set of core analyzers.
-    /// </remarks>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class DoNotCreateStructWithNoDefaultStructConstructionAttributeAnalyzer : DefaultStructConstructionAnalyzerBase
     {

--- a/src/ErrorProne.NET.StructAnalyzers/NonDefaultStructs/DoNotEmbedStructsWithNoDefaultStructConstructionAttributeAnalyzer.cs
+++ b/src/ErrorProne.NET.StructAnalyzers/NonDefaultStructs/DoNotEmbedStructsWithNoDefaultStructConstructionAttributeAnalyzer.cs
@@ -1,10 +1,11 @@
 using System.Linq;
+using ErrorProne.NET.StructAnalyzers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
-namespace ErrorProne.NET.CoreAnalyzers.NonDefaultStructs
+namespace ErrorProne.Net.StructAnalyzers.NonDefaultStructs
 {
     /// <summary>
     /// Analyzer warns when a struct with non-default invariants is embedded into another struct.

--- a/src/ErrorProne.NET.StructAnalyzers/ToDo.txt
+++ b/src/ErrorProne.NET.StructAnalyzers/ToDo.txt
@@ -1,17 +1,9 @@
-﻿- Do not warn when readonly struct is passed by value into constructor. Done
-- Make 'use 'in'-modifier an informational message instead of a warning. 
-
-- Do not warn on readonly struct passed by in if a method is overriden or implements an interface. Done
-- Do not warn if 'non-readonly friendly struct' is passed by 'in' in the same struct. Done
-
+﻿
 - Warn if readonly struct is passed by ref (should be info message).
 - Implement: pass parameter by 'in' refactoring.
 - Cache non-source types for IsReadOnly.
 - Large struct used in many methods? Stateful analysis is required.
 - Hidden copy: when an extension method is used that takes a struct by value.
-- Analyze ref readonly locals. Done
-- Analyze local functions. Done
-- Show all hidden copies for structs (info message? Would be good to turn this diagnostics on and off). Done
 - Equals and gethashcode are asymmetrical (different props/fields are used). (not sure about that)
 
 Known limitations


### PR DESCRIPTION
This PR moves the analyzers responsible for checking structs marked with `DoNotUseDefaultConstructionAttribute` into ErrorProne.Structs and emits diagnostics in the following cases:

```csharp
[DoNotUseDefaultConstructionAttribute]
public struct MyS
{
  public MyS(int n) {}
}
public class Foo
{
    public void Check1()
    {
        CreateOutput<MyS>(out var s);
//     ~~~~~~~~~~~~~~~~~~~~

        CreateRef(ref s);
//     ~~~~~~~~~~

        s = Create<MyS>();
//           ~~~~~~~~~~
        s = Create2<int, MyS>(42);
//           ~~~~~~~~~~~~~~~
    }

    // Should warn even without any constraints.
    public static void CreateOutput<T>(out T t)
    {
        t = default;
    }
    
    public static void CreateRef<T>(ref T t)
    {
        t = default;
    }

    public static T Create<T>() where T: new() => new T();
    public static U Create2<T, U>(T t) where U: new() => new U();
}
```