### PR TITLE
Support configuring large struct threshold

### DIFF
--- a/src/ErrorProne.NET.StructAnalyzers.Tests/StructSizeCalculatorIntegrationTests.cs
+++ b/src/ErrorProne.NET.StructAnalyzers.Tests/StructSizeCalculatorIntegrationTests.cs
@@ -1,8 +1,7 @@
 ﻿using System;
+using System.Threading.Tasks;
 using ErrorProne.NET.TestHelpers;
 using NUnit.Framework;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using VerifyCS = ErrorProne.NET.TestHelpers.CSharpCodeFixVerifier<
     ErrorProne.NET.StructAnalyzers.UseInModifierForReadOnlyStructAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
@@ -15,21 +14,19 @@ namespace ErrorProne.NET.StructAnalyzers.Tests
     [TestFixture]
     public class StructSizeCalculatorIntegrationTests
     {
-        [SetUp]
-        public void Initializer()
-        {
-            Settings.SetLargeStructThresholdForTestingPurposesOnly(3 * IntPtr.Size);
-        }
-
         [Test]
         public async Task GetOnlyPropertyShouldBeIgnoredBySizeCalculator()
         {
             string code = @"
-readonly struct S { private readonly object _o1, _o2; public object Foo => null; }
+readonly struct S { private readonly object _o1, _o2, _o3; public object Foo => null; }
 class Foo {
    public static void Bar(S s) {}
 }";
-            await VerifyCS.VerifyAsync(code);
+
+            await new VerifyCS.Test
+            {
+                TestCode = code,
+            }.WithLargeStructThreshold(4 * sizeof(long)).RunAsync();
         }
         
         [Test]
@@ -39,7 +36,11 @@ class Foo {
 class Foo {
    public static void Bar(System.ArraySegment<byte> s) {}
 }";
-            await VerifyCS.VerifyAsync(code);
+
+            await new VerifyCS.Test
+            {
+                TestCode = code,
+            }.RunAsync();
         }
     }
 }

--- a/src/RoslynNunitTestRunner/CodeFixTestExtensions.cs
+++ b/src/RoslynNunitTestRunner/CodeFixTestExtensions.cs
@@ -1,5 +1,7 @@
-﻿using Microsoft.CodeAnalysis.Testing;
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Testing.Verifiers;
+using Microsoft.CodeAnalysis.Text;
 
 namespace ErrorProne.NET.TestHelpers
 {
@@ -78,6 +80,24 @@ internal sealed class NonDefaultableAttribute : System.Attribute
             {
                 test.BatchFixedState.Sources.Add(file);
             }
+
+            return test;
+        }
+
+        public static TTest WithLargeStructThreshold<TTest>(this TTest test, int largeStructThreshold)
+            where TTest : CodeFixTest<NUnitVerifier>
+        {
+            var content = $@"root = true
+
+[*.{{cs,vb}}]
+error_prone.large_struct_threshold = {largeStructThreshold}
+";
+
+            test.SolutionTransforms.Add((solution, projectId) =>
+            {
+                var documentId = DocumentId.CreateNewId(projectId, ".editorconfig");
+                return solution.AddAnalyzerConfigDocument(documentId, ".editorconfig", SourceText.From(content), filePath: "/.editorconfig");
+            });
 
             return test;
         }


### PR DESCRIPTION
Adds a new .editorconfig option:

```
error_prone.large_struct_threshold = 24
```