### PR TITLE
Support readonly members for structs

### DIFF
--- a/src/RoslynNunitTestRunner/CSharpCodeFixVerifier`2+Test.cs
+++ b/src/RoslynNunitTestRunner/CSharpCodeFixVerifier`2+Test.cs
@@ -16,6 +16,7 @@ namespace ErrorProne.NET.TestHelpers
             return new Test
             {
                 TestState = { Sources = { code } }
+                
             }.WithoutGeneratedCodeVerification().RunAsync();
         }
 
@@ -40,7 +41,7 @@ namespace ErrorProne.NET.TestHelpers
                 });
             }
 
-            public LanguageVersion LanguageVersion { get; set; } = LanguageVersion.CSharp7_3;
+            public LanguageVersion LanguageVersion { get; set; } = LanguageVersion.CSharp8;
         }
     }
 }


### PR DESCRIPTION
Readonly members are special because they do not cause hidden copies in "readonly" contexts.