### PR TITLE
Fix issue with readonly structs like ReadOnlyMemory

### DIFF
--- a/samples/ErrorProne.Samples/App.config
+++ b/samples/ErrorProne.Samples/App.config
@@ -1,6 +1,14 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
     </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/samples/ErrorProne.Samples/ErrorProne.Samples.csproj
+++ b/samples/ErrorProne.Samples/ErrorProne.Samples.csproj
@@ -45,11 +45,17 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Buffers.4.5.1\lib\netstandard1.1\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>packages\System.Collections.Immutable.1.1.37\lib\dotnet\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Core" />
+    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Memory.4.5.4\lib\netstandard1.1\System.Memory.dll</HintPath>
+    </Reference>
     <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll</HintPath>
       <Private>True</Private>
@@ -69,6 +75,9 @@
     <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>packages\System.Reflection.Metadata.1.1.0\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\netstandard1.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -96,6 +105,7 @@
     <Compile Include="SideEffectAnalysis.cs" />
     <Compile Include="StringFormatAnalysis.cs" />
     <Compile Include="StructAnalyzers\MakeStructReadOnlySample.cs" />
+    <Compile Include="StructAnalyzers\TestReadOnlyMemory.cs" />
     <Compile Include="SwitchOverEnum.cs" />
     <Compile Include="WorkInProgress.cs" />
   </ItemGroup>

--- a/samples/ErrorProne.Samples/StructAnalyzers/MakeStructReadOnlySample.cs
+++ b/samples/ErrorProne.Samples/StructAnalyzers/MakeStructReadOnlySample.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;

--- a/samples/ErrorProne.Samples/StructAnalyzers/TestReadOnlyMemory.cs
+++ b/samples/ErrorProne.Samples/StructAnalyzers/TestReadOnlyMemory.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace ErrorProne.Samples.StructAnalyzers
+{
+    public static class TestReadOnlyMemory
+    {
+        public static void WithReadOnlySequence(in ReadOnlyMemory<byte> r)
+        {
+
+        }
+    }
+}

--- a/samples/ErrorProne.Samples/packages.config
+++ b/samples/ErrorProne.Samples/packages.config
@@ -10,18 +10,21 @@
   <package id="Rx-Linq" version="2.2.5" targetFramework="net452" />
   <package id="Rx-Main" version="2.2.5" targetFramework="net452" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net452" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net452" />
   <package id="System.Collections" version="4.0.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />
   <package id="System.Diagnostics.Debug" version="4.0.0" targetFramework="net452" />
   <package id="System.Globalization" version="4.0.0" targetFramework="net452" />
   <package id="System.IO" version="4.0.0" targetFramework="net452" />
   <package id="System.Linq" version="4.0.0" targetFramework="net452" />
+  <package id="System.Memory" version="4.5.4" targetFramework="net452" />
   <package id="System.Reflection" version="4.0.0" targetFramework="net452" />
   <package id="System.Reflection.Extensions" version="4.0.0" targetFramework="net452" />
   <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="net452" />
   <package id="System.Reflection.Primitives" version="4.0.0" targetFramework="net452" />
   <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net452" />
   <package id="System.Runtime" version="4.0.0" targetFramework="net452" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net452" />
   <package id="System.Runtime.Extensions" version="4.0.0" targetFramework="net452" />
   <package id="System.Runtime.InteropServices" version="4.0.0" targetFramework="net452" />
   <package id="System.Text.Encoding" version="4.0.0" targetFramework="net452" />


### PR DESCRIPTION
Fixes #84.

When I originally wrote the analyzers the `IType.IsReadOnly` was not exposed. So I did some hacks to get this value. Apparently the hack was not very reliable.

But after C# 8 release, I actually want to remove all the analyzers that warns that non-readonly structs is used in readonly contexts (like passed by `in`) because in C# 8 there are a lot more cases when copy of non-readonly struct is avoided (like auto-properties and other forms of readonly members).