### PR TITLE
Fix contract violation if some types are missing

### DIFF
--- a/src/ErrorProne.NET.Core/CompilationExtensions.cs
+++ b/src/ErrorProne.NET.Core/CompilationExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics.ContractsLight;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 
@@ -8,20 +7,18 @@ namespace ErrorProne.NET.Core
     // Copied from internal ICompilationExtensions class from the roslyn codebase
     public static class CompilationExtensions
     {
-        public static INamedTypeSymbol GetTypeByFullName(this Compilation compilation, string fullName)
+        public static INamedTypeSymbol? GetTypeByFullName(this Compilation compilation, string fullName)
         {
-            var result = compilation.GetTypeByMetadataName(fullName);
-            Contract.Assert(result != null, $"Can't find type '{fullName}'.");
-            return result;
+            return compilation.GetBestTypeByMetadataName(fullName);
         }
 
-        public static INamedTypeSymbol TaskType(this Compilation compilation)
+        public static INamedTypeSymbol? TaskType(this Compilation compilation)
             => compilation.GetTypeByFullName(typeof(Task).FullName);
 
-        public static INamedTypeSymbol TaskOfTType(this Compilation compilation)
+        public static INamedTypeSymbol? TaskOfTType(this Compilation compilation)
             => compilation.GetTypeByFullName(typeof(Task<>).FullName);
 
-        public static INamedTypeSymbol ValueTaskOfTType(this Compilation compilation)
+        public static INamedTypeSymbol? ValueTaskOfTType(this Compilation compilation)
             => compilation.GetTypeByFullName("System.Threading.Tasks.ValueTask`1");
 
         public static bool IsSystemObject(this INamedTypeSymbol type)
@@ -33,7 +30,7 @@ namespace ErrorProne.NET.Core
         public static bool IsSystemValueType(this INamedTypeSymbol type, Compilation compilation)
             => type.Equals(compilation.GetTypeByFullName("System.ValueType"), SymbolEqualityComparer.Default);
 
-        public static (INamedTypeSymbol taskType, INamedTypeSymbol taskOfTType, INamedTypeSymbol valueTaskOfTTypeOpt) GetTaskTypes(Compilation compilation)
+        public static (INamedTypeSymbol? taskType, INamedTypeSymbol? taskOfTType, INamedTypeSymbol? valueTaskOfTTypeOpt) GetTaskTypes(Compilation compilation)
         {
             var taskType = compilation.TaskType();
             var taskOfTType = compilation.TaskOfTType();
@@ -82,6 +79,79 @@ namespace ErrorProne.NET.Core
         public static bool IsErrorType(this ITypeSymbol symbol)
         {
             return symbol?.TypeKind == TypeKind.Error;
+        }
+
+        /// <summary>
+        /// Gets a type by its metadata name to use for code analysis within a <see cref="Compilation"/>. This method
+        /// attempts to find the "best" symbol to use for code analysis, which is the symbol matching the first of the
+        /// following rules.
+        ///
+        /// <list type="number">
+        ///   <item><description>
+        ///     If only one type with the given name is found within the compilation and its referenced assemblies, that
+        ///     type is returned regardless of accessibility.
+        ///   </description></item>
+        ///   <item><description>
+        ///     If the current <paramref name="compilation"/> defines the symbol, that symbol is returned.
+        ///   </description></item>
+        ///   <item><description>
+        ///     If exactly one referenced assembly defines the symbol in a manner that makes it visible to the current
+        ///     <paramref name="compilation"/>, that symbol is returned.
+        ///   </description></item>
+        ///   <item><description>
+        ///     Otherwise, this method returns <see langword="null"/>.
+        ///   </description></item>
+        /// </list>
+        /// </summary>
+        /// <param name="compilation">The <see cref="Compilation"/> to consider for analysis.</param>
+        /// <param name="fullyQualifiedMetadataName">The fully-qualified metadata type name to find.</param>
+        /// <returns>The symbol to use for code analysis; otherwise, <see langword="null"/>.</returns>
+        /// <remarks>
+        /// This code is copied from github.com/dotnet/roslyn/blob/master/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/CompilationExtensions.cs
+        /// </remarks>
+        public static INamedTypeSymbol? GetBestTypeByMetadataName(this Compilation compilation, string fullyQualifiedMetadataName)
+        {
+            // Try to get the unique type with this name, ignoring accessibility
+            var type = compilation.GetTypeByMetadataName(fullyQualifiedMetadataName);
+
+            // Otherwise, try to get the unique type with this name originally defined in 'compilation'
+            type ??= compilation.Assembly.GetTypeByMetadataName(fullyQualifiedMetadataName);
+
+            // Otherwise, try to get the unique accessible type with this name from a reference
+            if (type is null)
+            {
+                foreach (var module in compilation.Assembly.Modules)
+                {
+                    foreach (var referencedAssembly in module.ReferencedAssemblySymbols)
+                    {
+                        var currentType = referencedAssembly.GetTypeByMetadataName(fullyQualifiedMetadataName);
+                        if (currentType is null)
+                        {
+                            continue;
+                        }
+
+                        switch (currentType.GetResultantVisibility())
+                        {
+                            case SymbolVisibility.Public:
+                            case SymbolVisibility.Internal when referencedAssembly.GivesAccessTo(compilation.Assembly):
+                                break;
+
+                            default:
+                                continue;
+                        }
+
+                        if (type is object)
+                        {
+                            // Multiple visible types with the same metadata name are present
+                            return null;
+                        }
+
+                        type = currentType;
+                    }
+                }
+            }
+
+            return type;
         }
     }
 }

--- a/src/ErrorProne.NET.Core/SymbolExtensions.cs
+++ b/src/ErrorProne.NET.Core/SymbolExtensions.cs
@@ -10,6 +10,13 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace ErrorProne.NET.Core
 {
+    public enum SymbolVisibility
+    {
+        Public,
+        Internal,
+        Private,
+    }
+
     /// <nodoc />
     public static class SymbolExtensions
     {
@@ -28,6 +35,53 @@ namespace ErrorProne.NET.Core
             }
 
             return false;
+        }
+
+        public static SymbolVisibility GetResultantVisibility(this ISymbol symbol)
+        {
+            // Start by assuming it's visible.
+            var visibility = SymbolVisibility.Public;
+
+            switch (symbol.Kind)
+            {
+                case SymbolKind.Alias:
+                    // Aliases are uber private.  They're only visible in the same file that they
+                    // were declared in.
+                    return SymbolVisibility.Private;
+
+                case SymbolKind.Parameter:
+                    // Parameters are only as visible as their containing symbol
+                    return GetResultantVisibility(symbol.ContainingSymbol);
+
+                case SymbolKind.TypeParameter:
+                    // Type Parameters are private.
+                    return SymbolVisibility.Private;
+            }
+
+            while (symbol != null && symbol.Kind != SymbolKind.Namespace)
+            {
+                switch (symbol.DeclaredAccessibility)
+                {
+                    // If we see anything private, then the symbol is private.
+                    case Accessibility.NotApplicable:
+                    case Accessibility.Private:
+                        return SymbolVisibility.Private;
+
+                    // If we see anything internal, then knock it down from public to
+                    // internal.
+                    case Accessibility.Internal:
+                    case Accessibility.ProtectedAndInternal:
+                        visibility = SymbolVisibility.Internal;
+                        break;
+
+                    // For anything else (Public, Protected, ProtectedOrInternal), the
+                    // symbol stays at the level we've gotten so far.
+                }
+
+                symbol = symbol.ContainingSymbol;
+            }
+
+            return visibility;
         }
 
         public static IEnumerable<ISymbol> GetAllUsedSymbols(Compilation compilation, SyntaxNode root)

--- a/src/ErrorProne.NET.Core/WellKnownTypesProvider.cs
+++ b/src/ErrorProne.NET.Core/WellKnownTypesProvider.cs
@@ -8,7 +8,7 @@ namespace ErrorProne.NET.Core
         private static readonly SymbolDisplayFormat SymbolDisplayFormat = new SymbolDisplayFormat(
             typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces);
 
-        public static INamedTypeSymbol GetExceptionType(this SemanticModel model)
+        public static INamedTypeSymbol? GetExceptionType(this SemanticModel model)
         {
             return model.Compilation.GetTypeByFullName(typeof(Exception).FullName);
         }
@@ -23,17 +23,17 @@ namespace ErrorProne.NET.Core
             return model.Compilation.GetSpecialType(SpecialType.System_Object);
         }
 
-        public static INamedTypeSymbol GetClrType(this SemanticModel model, Type type)
+        public static INamedTypeSymbol? GetClrType(this SemanticModel model, Type type)
         {
             return model.Compilation.GetTypeByFullName(type.FullName);
         }
 
-        public static INamedTypeSymbol GetClrType(this Compilation compilation, Type type)
+        public static INamedTypeSymbol? GetClrType(this Compilation compilation, Type type)
         {
             return compilation.GetClrType(type.FullName);
         }
 
-        public static INamedTypeSymbol GetClrType(this Compilation compilation, string fullName)
+        public static INamedTypeSymbol? GetClrType(this Compilation compilation, string fullName)
         {
             return compilation.GetTypeByFullName(fullName);
         }

--- a/src/ErrorProne.NET.StructAnalyzers/AnalyzerReleases.Unshipped.md
+++ b/src/ErrorProne.NET.StructAnalyzers/AnalyzerReleases.Unshipped.md
@@ -12,3 +12,4 @@ EPS08 | Performance | Warning | DefaultEqualsOrHashCodeIsUsedInStructAnalyzer
 EPS09 | Usage | Info | ExplicitInParameterAnalyzer
 EPS10 | CodeSmell | Warning | DoNotCreateStructWithNoDefaultStructConstructionAttributeAnalyzer
 EPS11 | CodeSmell | Warning | DoNotEmbedStructsWithNoDefaultStructConstructionAttributeAnalyzer
+EPS12 | Performance | Warning | MakeStructMemberReadOnlyAnalyzer


### PR DESCRIPTION
For instance, if the project under analysis does not reference `System.Collections.Immutable` or `System.ValueTuple` some analyzers used to throw contract violation, because there was an assumption that some types must be present in `Compilation` object. But this is not the case. So the api now allows returning null.