### PR TITLE
Warn when a non-defaultable struct doesn't have a constructor

### DIFF
--- a/samples/ErrorProne.Samples/CoreAnalyzers/DefaultContrcutionSample.cs
+++ b/samples/ErrorProne.Samples/CoreAnalyzers/DefaultContrcutionSample.cs
@@ -14,6 +14,12 @@ namespace ErrorProne.Samples.CoreAnalyzers
         // Other members
     }
 
+    [NonDefaultable]
+    public readonly struct NonDefaultableStruct
+    {
+        // Warn on a missing custom constructor.
+    }
+
     public class DefaultConstructionSample
     {
         public static void Sample()
@@ -21,6 +27,15 @@ namespace ErrorProne.Samples.CoreAnalyzers
             // Do not use default construction for struct 'TaskSourceSlim' marked with 'DoNotUseDefaultConstruction' attribute
             var tss = new TaskSourceSlim<object>();
             
+            // This one is still fine!
+            (TaskSourceSlim<int> tcs, int v) x = default;
+
+            // Ok as well.
+            TaskSourceSlim<int>[] tcsArray = new TaskSourceSlim<int>[10];
+            
+            // Warns here
+            tcsArray[0] = default;
+
             // The same warning.
             TaskSourceSlim<object> tss2 = default;
 

--- a/samples/ErrorProne.Samples/ErrorProne.Samples.csproj
+++ b/samples/ErrorProne.Samples/ErrorProne.Samples.csproj
@@ -78,6 +78,9 @@
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\netstandard1.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.ValueTuple.4.5.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/samples/ErrorProne.Samples/packages.config
+++ b/samples/ErrorProne.Samples/packages.config
@@ -28,4 +28,5 @@
   <package id="System.Text.Encoding" version="4.0.0" targetFramework="net452" />
   <package id="System.Text.Encoding.Extensions" version="4.0.0" targetFramework="net452" />
   <package id="System.Threading" version="4.0.0" targetFramework="net452" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net452" />
 </packages>

--- a/src/ErrorProne.NET.StructAnalyzers.Tests/NonDefaultableStructDeclarationTests.cs
+++ b/src/ErrorProne.NET.StructAnalyzers.Tests/NonDefaultableStructDeclarationTests.cs
@@ -1,0 +1,52 @@
+﻿using ErrorProne.NET.TestHelpers;
+using NUnit.Framework;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp;
+using VerifyCS = ErrorProne.NET.TestHelpers.CSharpCodeFixVerifier<
+    ErrorProne.Net.StructAnalyzers.NonDefaultStructs.NonDefaultableStructDeclarationAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+
+namespace ErrorProne.NET.CoreAnalyzers.Tests
+{
+    [TestFixture]
+    public class NonDefaultableStructDeclarationTests
+    {
+        // TODO: add support for record structs once available.
+        [Test]
+        public async Task Warn_If_Constructor_Is_Missing()
+        {
+            string code = @"
+[NonDefaultableAttribute]
+public struct [|MyS|] { }
+";
+
+            await VerifySource(code);
+        }
+        
+        [Test]
+        public async Task No_Warn_If_Constructor_Is_Present()
+        {
+            string code = @"
+[NonDefaultableAttribute]
+public struct MyS { public MyS(int x) {} }
+";
+
+            await VerifySource(code);
+        }
+
+        private static async Task VerifySource(string code)
+        {
+            await new VerifyCS.Test
+                {
+                    TestState =
+                    {
+                        Sources = {code},
+                    },
+                    LanguageVersion = LanguageVersion.Latest,
+                }
+                .WithNonDefaultableAttribute()
+                .WithoutGeneratedCodeVerification()
+                .RunAsync();
+        }
+    }
+}

--- a/src/ErrorProne.NET.StructAnalyzers/AnalyzerReleases.Unshipped.md
+++ b/src/ErrorProne.NET.StructAnalyzers/AnalyzerReleases.Unshipped.md
@@ -13,3 +13,4 @@ EPS09 | Usage | Info | ExplicitInParameterAnalyzer
 EPS10 | CodeSmell | Warning | DoNotCreateStructWithNoDefaultStructConstructionAttributeAnalyzer
 EPS11 | CodeSmell | Warning | DoNotEmbedStructsWithNoDefaultStructConstructionAttributeAnalyzer
 EPS12 | Performance | Warning | MakeStructMemberReadOnlyAnalyzer
+EPS13 | Usage | Warning | NonDefaultableStructDeclarationAnalyzer

--- a/src/ErrorProne.NET.StructAnalyzers/DiagnosticIds.cs
+++ b/src/ErrorProne.NET.StructAnalyzers/DiagnosticIds.cs
@@ -1,4 +1,6 @@
-﻿namespace ErrorProne.NET.StructAnalyzers
+﻿using Microsoft.CodeAnalysis;
+
+namespace ErrorProne.NET.StructAnalyzers
 {
     /// <summary>
     /// Diagnostics produced by this project.
@@ -31,6 +33,17 @@
 
         /// <nodoc />
         public const string MakeStructMemberReadOnly = "EPS12";
+    }
 
+    public static class Diagnostics
+    {
+        public const string UsageCategory = "Usage";
+
+        public static DiagnosticDescriptor EPS13 { get; } = new DiagnosticDescriptor(
+            nameof(EPS13),
+            "A non-defaultable struct must declare a constructor.",
+            "A non-defaultable struct {0} must declare a constructor.",
+            UsageCategory, DiagnosticSeverity.Warning, isEnabledByDefault: true,
+            description: "A non-defaultable struct must be created with a constructor so you must declare one in order to use it.");
     }
 }

--- a/src/ErrorProne.NET.StructAnalyzers/DiagnosticIds.cs
+++ b/src/ErrorProne.NET.StructAnalyzers/DiagnosticIds.cs
@@ -3,7 +3,7 @@
 namespace ErrorProne.NET.StructAnalyzers
 {
     /// <summary>
-    /// Diagnostics produced by this project.
+    /// DiagnosticDescriptors produced by this project.
     /// </summary>
     public static class DiagnosticIds
     {
@@ -35,11 +35,11 @@ namespace ErrorProne.NET.StructAnalyzers
         public const string MakeStructMemberReadOnly = "EPS12";
     }
 
-    public static class Diagnostics
+    internal static class DiagnosticDescriptors
     {
         public const string UsageCategory = "Usage";
 
-        public static DiagnosticDescriptor EPS13 { get; } = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor EPS13 = new DiagnosticDescriptor(
             nameof(EPS13),
             "A non-defaultable struct must declare a constructor.",
             "A non-defaultable struct {0} must declare a constructor.",

--- a/src/ErrorProne.NET.StructAnalyzers/NonDefaultableStructs/NonDefaultableStructAnalysis.cs
+++ b/src/ErrorProne.NET.StructAnalyzers/NonDefaultableStructs/NonDefaultableStructAnalysis.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using ErrorProne.NET.Core;
+
+namespace ErrorProne.Net.StructAnalyzers.NonDefaultStructs
+{
+    /// <summary>
+    /// Contains core business logic for analyzing non-defaultable structs.
+    /// </summary>
+    public static class NonDefaultableStructAnalysis
+    {
+        public const string NonDefaultableAttributeName = "NonDefaultableAttribute";
+
+        private static readonly List<Type> SpecialTypes = new List<Type>
+        {
+            typeof(ImmutableArray<>)
+        };
+
+        /// <summary>
+        /// Returns true if a given <paramref name="type"/> should not be created via 'default' expression.
+        /// </summary>
+        /// <remarks>
+        /// The method covers types marked with <see cref="NonDefaultableAttributeName"/> or special types like <code>ImmutableArray{T}</code>.
+        /// </remarks>
+        public static bool DoNotUseDefaultConstruction(this ITypeSymbol type, Compilation compilation, out string? message)
+        {
+            message = null;
+
+            var attributes = type.GetAttributes();
+            var doNotUseDefaultAttribute = attributes.FirstOrDefault(a =>
+                a.AttributeClass.Name.StartsWith(NonDefaultableAttributeName));
+
+            if (doNotUseDefaultAttribute != null)
+            {
+                var constructorArg = doNotUseDefaultAttribute.ConstructorArguments.FirstOrDefault();
+                message = !constructorArg.IsNull ? constructorArg.Value?.ToString() : null;
+                return true;
+            }
+
+            if (SpecialTypes.Any(t => type.IsClrType(compilation, t)))
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/ErrorProne.NET.StructAnalyzers/NonDefaultableStructs/NonDefaultableStructAnalyzerBase.cs
+++ b/src/ErrorProne.NET.StructAnalyzers/NonDefaultableStructs/NonDefaultableStructAnalyzerBase.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis;
 namespace ErrorProne.Net.StructAnalyzers.NonDefaultStructs
 {
     /// <summary>
-    /// A base class for analyzing structs marked with <see cref="NonDefaultableAttributeName"/>.
+    /// A base class for analyzing structs marked with <see cref="NonDefaultableStructAnalysis.NonDefaultableAttributeName"/>.
     /// </summary>
     public abstract class NonDefaultableStructAnalyzerBase : DiagnosticAnalyzerBase
     {

--- a/src/ErrorProne.NET.StructAnalyzers/NonDefaultableStructs/NonDefaultableStructDeclarationAnalyzer.cs
+++ b/src/ErrorProne.NET.StructAnalyzers/NonDefaultableStructs/NonDefaultableStructDeclarationAnalyzer.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Linq;
 using ErrorProne.NET.Core;
 using ErrorProne.NET.CoreAnalyzers;
@@ -16,7 +17,10 @@ namespace ErrorProne.Net.StructAnalyzers.NonDefaultStructs
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class NonDefaultableStructDeclarationAnalyzer : DiagnosticAnalyzerBase
     {
-        private static readonly DiagnosticDescriptor DiagnosticDescriptor = Diagnostics.EPS13;
+        private static readonly DiagnosticDescriptor DiagnosticDescriptor = DiagnosticDescriptors.EPS13;
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => new ImmutableArray<DiagnosticDescriptor>().Add(DiagnosticDescriptors.EPS13);
+
         /// <nodoc />
         public NonDefaultableStructDeclarationAnalyzer() : base(DiagnosticDescriptor)
         {

--- a/src/ErrorProne.NET.StructAnalyzers/NonDefaultableStructs/NonDefaultableStructDeclarationAnalyzer.cs
+++ b/src/ErrorProne.NET.StructAnalyzers/NonDefaultableStructs/NonDefaultableStructDeclarationAnalyzer.cs
@@ -1,0 +1,49 @@
+using System.Linq;
+using ErrorProne.NET.Core;
+using ErrorProne.NET.CoreAnalyzers;
+using ErrorProne.NET.StructAnalyzers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace ErrorProne.Net.StructAnalyzers.NonDefaultStructs
+{
+    /// <summary>
+    /// An analyzer that checks that a struct marked with <see cref="NonDefaultableStructAnalysis.NonDefaultableAttributeName"/> is declared correctly
+    /// (for instance, that it does have a non-default constructor).
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class NonDefaultableStructDeclarationAnalyzer : DiagnosticAnalyzerBase
+    {
+        private static readonly DiagnosticDescriptor DiagnosticDescriptor = Diagnostics.EPS13;
+        /// <nodoc />
+        public NonDefaultableStructDeclarationAnalyzer() : base(DiagnosticDescriptor)
+        {
+        }
+
+        /// <inheritdoc />
+        protected override void InitializeCore(AnalysisContext context)
+        {
+            context.RegisterSyntaxNodeAction(AnalyzeStructDeclaration, SyntaxKind.StructDeclaration);
+        }
+
+        private void AnalyzeStructDeclaration(SyntaxNodeAnalysisContext context)
+        {
+            var structDeclaration = (StructDeclarationSyntax)context.Node;
+            var semanticMode = context.SemanticModel;
+
+            var typeSymbol = semanticMode.GetDeclaredSymbol(structDeclaration); 
+            if (typeSymbol is not null &&
+                typeSymbol.DoNotUseDefaultConstruction(context.Compilation, out _))
+            {
+                // All the structs have a default constructor, but explicit constructors
+                // have non empty 'DeclaringSyntaxReferences'.
+                if (!typeSymbol.InstanceConstructors.Any(c => c.DeclaringSyntaxReferences.Length != 0))
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptor, structDeclaration.Identifier.GetLocation(), structDeclaration.Identifier.ToFullString()));
+                }
+            }
+        }
+    }
+}

--- a/src/ErrorProne.NET.StructAnalyzers/NonDefaultableStructs/NonDefaultableStructDeclarationAnalyzer.cs
+++ b/src/ErrorProne.NET.StructAnalyzers/NonDefaultableStructs/NonDefaultableStructDeclarationAnalyzer.cs
@@ -19,8 +19,6 @@ namespace ErrorProne.Net.StructAnalyzers.NonDefaultStructs
     {
         private static readonly DiagnosticDescriptor DiagnosticDescriptor = DiagnosticDescriptors.EPS13;
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => new ImmutableArray<DiagnosticDescriptor>().Add(DiagnosticDescriptors.EPS13);
-
         /// <nodoc />
         public NonDefaultableStructDeclarationAnalyzer() : base(DiagnosticDescriptor)
         {

--- a/src/ErrorProne.NET.StructAnalyzers/NonDefaultableStructs/NonDefaultableStructsCreationAnalyzer.cs
+++ b/src/ErrorProne.NET.StructAnalyzers/NonDefaultableStructs/NonDefaultableStructsCreationAnalyzer.cs
@@ -10,7 +10,7 @@ namespace ErrorProne.Net.StructAnalyzers.NonDefaultStructs
     /// For instance <code>ImmutableArray&lt;int&gt; a = default; int x = a.Count; will fail with NRE.</code>
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class NonDefaultableStructsConstructionAnalyzer : NonDefaultableStructAnalyzerBase
+    public sealed class NonDefaultableStructsCreationAnalyzer : NonDefaultableStructAnalyzerBase
     {
         /// <nodoc />
         public const string DiagnosticId = DiagnosticIds.DoNotUseDefaultConstructionForStruct;
@@ -30,7 +30,7 @@ namespace ErrorProne.Net.StructAnalyzers.NonDefaultStructs
             new DiagnosticDescriptor(DiagnosticId, Title, Message, Category, Severity, isEnabledByDefault: true, description: Description);
 
         /// <nodoc />
-        public NonDefaultableStructsConstructionAnalyzer()
+        public NonDefaultableStructsCreationAnalyzer()
             : base(Rule)
         {
         }

--- a/src/ErrorProne.NET.StructAnalyzers/Settings.cs
+++ b/src/ErrorProne.NET.StructAnalyzers/Settings.cs
@@ -4,7 +4,7 @@ namespace ErrorProne.NET.StructAnalyzers
 {
     public static class Settings
     {
-        public static int DefaultLargeStructThreshold = 5 * sizeof(long);
+        public static int DefaultLargeStructThreshold { get; private set; } = 5 * sizeof(long);
         private const int MaxLargeStructThreshold = 1_000_000;
 
         public static void SetDefaultLargeStructThreshold(int newThreshold) =>


### PR DESCRIPTION
Plus, fixing #230 and #226.