### PR TITLE
Don't descend into attribute lists when looking for assignments to 'this'

### DIFF
--- a/src/ErrorProne.NET.StructAnalyzers/ReadOnlyAnalyzer.cs
+++ b/src/ErrorProne.NET.StructAnalyzers/ReadOnlyAnalyzer.cs
@@ -115,8 +115,9 @@ namespace ErrorProne.NET.StructAnalyzers
 
             // So we use a mixture of syntax-based and the dataflow-based approaches.
             var mutations = syntax
-                .DescendantNodesAndSelf()
-                // Looking for all expressions but for invocations.
+                .DescendantNodesAndSelf(
+                    descendIntoChildren: n => !(n is AttributeListSyntax))
+                // Looking for all expressions but not for invocations.
                 // All the invocations and the arguments covered separately.
                 .Where(n => n is ExpressionSyntax && !(n is InvocationExpressionSyntax))
                 .ToList();


### PR DESCRIPTION
I've done some Roslyn development in the past, but am not an expert. To the best of my understanding, there's no way an attribute could cause an assignment to 'this'. My change ignores attributes, and this stops later code triggering an exception in `Microsoft.CodeAnalysis.CSharp`. It may be that a broader category of nodes should be skipped here, and/or that the same logic should be applied in other places, but that needs more experienced and expert input. Fixes #249.