### PR TITLE
Updates from Progressive Insurance fork of Error Prone.net Closes #246 Closes #209 Closes #251 Closes #236 Closes #232 Closes #231 Closes #216 Closes #260

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -76,6 +76,8 @@ Correct exception handling is a very complex topic, but one case that is very co
 
 To avoid this anti-pattern, the analyzer will warn you if the code only traces the `Exception` property without "looking inside":
 
+**EPC12  - Suspicious exception handling: only '' is observed in the catch block.**
+
 ```csharp
 try
 {
@@ -87,7 +89,9 @@ catch (Exception e)
     Console.WriteLine(e.Message);
     //                  ~~~~~~~
 }
-
+```
+**ERP022 - swallows an unobserved exception.**
+```csharp
 try
 {
     Console.WriteLine();
@@ -98,7 +102,9 @@ catch (Exception e)
     return;
 //  ~~~~~~
 }
-
+```
+**ERP021 - incorrect exception propagation. Use 'throw;' instead**
+```csharp
 try
 {
     Console.WriteLine();

--- a/src/ErrorProne.NET.Cli/ErrorProne.NET.Cli.csproj
+++ b/src/ErrorProne.NET.Cli/ErrorProne.NET.Cli.csproj
@@ -12,11 +12,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.5.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.5.0" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.5.5" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.6.0" />
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
-    <PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.0.3" />
+    <PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.1.5" />
   </ItemGroup>
 
   <ItemGroup>
@@ -24,6 +24,12 @@
     <ProjectReference Include="..\ErrorProne.NET.CoreAnalyzers\ErrorProne.NET.CoreAnalyzers.csproj" />
     <ProjectReference Include="..\ErrorProne.NET.StructAnalyzers.CodeFixes\ErrorProne.NET.StructAnalyzers.CodeFixes.csproj" />
     <ProjectReference Include="..\ErrorProne.NET.StructAnalyzers\ErrorProne.NET.StructAnalyzers.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="ILRepack.Lib.MSBuild" Version="2.1.18" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.6.133" />
+    <PackageReference Update="RuntimeContracts" Version="0.5.0" />
   </ItemGroup>
 
 </Project>

--- a/src/ErrorProne.NET.Core/ErrorProne.NET.Core.csproj
+++ b/src/ErrorProne.NET.Core/ErrorProne.NET.Core.csproj
@@ -6,11 +6,17 @@
 
   <ItemGroup>
     <PackageReference Include="ErrorProne.NET.CoreAnalyzers" Version="0.1.2" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.5.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="ILRepack.Lib.MSBuild" Version="2.1.18" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.6.133" />
+    <PackageReference Update="RuntimeContracts" Version="0.5.0" />
   </ItemGroup>
 </Project>

--- a/src/ErrorProne.NET.CoreAnalyzers.CodeFixes/ErrorProne.NET.CoreAnalyzers.CodeFixes.csproj
+++ b/src/ErrorProne.NET.CoreAnalyzers.CodeFixes/ErrorProne.NET.CoreAnalyzers.CodeFixes.csproj
@@ -51,7 +51,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -63,6 +63,12 @@
 
   <ItemGroup>
     <None Update="tools\*.ps1" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="ILRepack.Lib.MSBuild" Version="2.1.18" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.6.133" />
+    <PackageReference Update="RuntimeContracts" Version="0.5.0" />
   </ItemGroup>
 
   <Target Name="_GetFilesToPackage">

--- a/src/ErrorProne.NET.CoreAnalyzers.Tests/CoreAnalyzers/SuspiciousExceptionHandling/OnlyMessageIsUsedTests.cs
+++ b/src/ErrorProne.NET.CoreAnalyzers.Tests/CoreAnalyzers/SuspiciousExceptionHandling/OnlyMessageIsUsedTests.cs
@@ -106,7 +106,35 @@ class FooBar {
                 },
             }.WithoutGeneratedCodeVerification().RunAsync();
         }
-
+        [Test]
+        public async Task Warn_On_Anonymous_Usage_Of_ExceptionMessage()
+        {
+            string code = @"
+using System.Collections;
+using System;
+class Test
+{
+    public ArrayList LoadList(string key, string subKey = """") {
+      var errors=new ArrayList();
+      try { new object();
+      } catch (Exception exception) {
+        errors.Add($""{new { key, subKey, exception.Message }}"");
+      }
+    return errors;
+    }
+}";
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources = { code },
+                    ExpectedDiagnostics =
+                    {
+                        VerifyCS.Diagnostic(SuspiciousExceptionHandlingAnalyzer.Rule).WithSpan(10, 52, 10, 59).WithArguments("exception"),
+                    },
+                },
+            }.WithoutGeneratedCodeVerification().RunAsync();
+        }
         [Test]
         public async Task NoWarn_When_Only_Message_Is_Used_But_Exception_Is_Not_Generic()
         {

--- a/src/ErrorProne.NET.CoreAnalyzers.Tests/CoreAnalyzers/SuspiciousExceptionHandling/SwallowAllExceptionsAnalyzer.cs
+++ b/src/ErrorProne.NET.CoreAnalyzers.Tests/CoreAnalyzers/SuspiciousExceptionHandling/SwallowAllExceptionsAnalyzer.cs
@@ -34,6 +34,29 @@ class Test
             }.WithoutGeneratedCodeVerification().RunAsync();
         }
 
+
+
+
+        [Test]
+        public async Task DoNotWarnOnAnonymousUsageOfException()
+        {
+            string code = @"
+using System.Collections;
+using System;
+class Test
+{
+    public ArrayList LoadList(string key, string subKey = """") {
+      var errors=new ArrayList();
+      try { new object();
+      } catch (Exception exception) {
+        errors.Add($""{new { key, subKey, exception }}"");
+      }
+    return errors;
+    }
+}";
+            await VerifyCS.VerifyAnalyzerAsync(code);
+        }
+
         [Test]
         public async Task NoWarnOnCatchWithFilter()
         {

--- a/src/ErrorProne.NET.CoreAnalyzers.Tests/ErrorProne.NET.CoreAnalyzers.Tests.csproj
+++ b/src/ErrorProne.NET.CoreAnalyzers.Tests/ErrorProne.NET.CoreAnalyzers.Tests.csproj
@@ -1,21 +1,27 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <EmbedRuntimeContracts>false</EmbedRuntimeContracts>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.5.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" PrivateAssets="all" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" PrivateAssets="all" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\ErrorProne.NET.CoreAnalyzers.CodeFixes\ErrorProne.NET.CoreAnalyzers.CodeFixes.csproj" />
     <ProjectReference Include="..\ErrorProne.NET.CoreAnalyzers\ErrorProne.NET.CoreAnalyzers.csproj" />
     <ProjectReference Include="..\RoslynNUnitTestRunner\ErrorProne.NET.TestHelpers.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="ILRepack.Lib.MSBuild" Version="2.1.18" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.6.133" />
+    <PackageReference Update="RuntimeContracts" Version="0.5.0" />
   </ItemGroup>
 
 </Project>

--- a/src/ErrorProne.NET.CoreAnalyzers/ErrorProne.NET.CoreAnalyzers.csproj
+++ b/src/ErrorProne.NET.CoreAnalyzers/ErrorProne.NET.CoreAnalyzers.csproj
@@ -13,8 +13,7 @@
    -->
   <ItemGroup>
     <Compile Include="..\ErrorProne.NET.Core\**.cs" Label="Core" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.5.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.6.0" />
   </ItemGroup>
 
   <PropertyGroup>
@@ -22,11 +21,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="ILRepack.Lib.MSBuild" Version="2.1.18" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.6.133" />
+    <PackageReference Update="RuntimeContracts" Version="0.5.0" />
   </ItemGroup>
   
 </Project>

--- a/src/ErrorProne.NET.CoreAnalyzers/ExceptionsAnalyzers/SuspiciousExceptionHandlingAnalyzer.cs
+++ b/src/ErrorProne.NET.CoreAnalyzers/ExceptionsAnalyzers/SuspiciousExceptionHandlingAnalyzer.cs
@@ -53,7 +53,7 @@ namespace ErrorProne.NET.CoreAnalyzers
                 var messageUsages = usages
                     .Select(id =>
                         new { Parent = id.Identifier.Parent as MemberAccessExpressionSyntax, Id = id.Identifier })
-                    .Where(x => x.Parent != null && x.Parent.Name.GetText().ToString() == "Message")
+                    .Where(x => x.Parent != null && x.Parent.Name.GetText().ToString().Trim() == "Message")
                     .ToList();
 
                 if (messageUsages.Count == 0)

--- a/src/ErrorProne.NET.CoreAnalyzers/ExceptionsAnalyzers/SwallowAllExceptionsAnalyzer.cs
+++ b/src/ErrorProne.NET.CoreAnalyzers/ExceptionsAnalyzers/SwallowAllExceptionsAnalyzer.cs
@@ -94,6 +94,7 @@ namespace ErrorProne.NET.ExceptionsAnalyzers
                 var u = usage.Identifier;
                 if (
                     u.Parent is ArgumentSyntax || // Exception object was used directly
+                    u.Parent is AnonymousObjectMemberDeclaratorSyntax || // Was used as an anonymous object member
                     u.Parent is AssignmentExpressionSyntax || // Was saved to field or local
                     // For instance in Console.WriteLine($"e = {e}");
                     u.Parent is InterpolationSyntax ||

--- a/src/ErrorProne.NET.StructAnalyzers.CodeFixes/ErrorProne.NET.StructAnalyzers.CodeFixes.csproj
+++ b/src/ErrorProne.NET.StructAnalyzers.CodeFixes/ErrorProne.NET.StructAnalyzers.CodeFixes.csproj
@@ -50,9 +50,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.5.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -64,6 +64,12 @@
 
   <ItemGroup>
     <None Update="tools\*.ps1" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="ILRepack.Lib.MSBuild" Version="2.1.18" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.6.133" />
+    <PackageReference Update="RuntimeContracts" Version="0.5.0" />
   </ItemGroup>
 
   <Target Name="_GetFilesToPackage">

--- a/src/ErrorProne.NET.StructAnalyzers.Tests/ErrorProne.NET.StructAnalyzers.Tests.csproj
+++ b/src/ErrorProne.NET.StructAnalyzers.Tests/ErrorProne.NET.StructAnalyzers.Tests.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <EmbedRuntimeContracts>false</EmbedRuntimeContracts>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.5.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" PrivateAssets="all" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" PrivateAssets="all" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>
@@ -19,7 +19,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.3.37" />
+    <PackageReference Update="ILRepack.Lib.MSBuild" Version="2.1.18" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.6.133" />
+    <PackageReference Update="RuntimeContracts" Version="0.5.0" />
   </ItemGroup>
 
 </Project>

--- a/src/ErrorProne.NET.StructAnalyzers/ErrorProne.NET.StructAnalyzers.csproj
+++ b/src/ErrorProne.NET.StructAnalyzers/ErrorProne.NET.StructAnalyzers.csproj
@@ -13,16 +13,22 @@
    -->
   <ItemGroup>
     <Compile Include="..\ErrorProne.NET.Core\**.cs" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.5.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.6.0" />
   </ItemGroup>
 
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+
+
+  <ItemGroup>
+    <PackageReference Update="ILRepack.Lib.MSBuild" Version="2.1.18" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.6.133" />
+    <PackageReference Update="RuntimeContracts" Version="0.5.0" />
   </ItemGroup>
 </Project>

--- a/src/ErrorProne.NET.Vsix/ErrorProne.NET.Vsix.csproj
+++ b/src/ErrorProne.NET.Vsix/ErrorProne.NET.Vsix.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.5.2044" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.6.2164" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>
@@ -34,7 +34,9 @@
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="Exists('$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets')" />
 
   <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.3.37" />
+    <PackageReference Update="ILRepack.Lib.MSBuild" Version="2.1.18" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.6.133" />
+    <PackageReference Update="RuntimeContracts" Version="0.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ILRepack.targets
+++ b/src/ILRepack.targets
@@ -14,7 +14,7 @@
       <!--<InternalizeExcludeAssemblies Include="RuntimeContracts" />-->
     </ItemGroup>
     <Message Text="MERGING: @(InputAssemblies->'%(Filename)') into $(OutputAssembly)" Importance="High" />
-    <ILRepack 
+    <!--<ILRepack 
       Parallel="true"
       DebugInfo="true"
       InputAssemblies="@(InputAssemblies)"
@@ -22,7 +22,7 @@
       OutputFile="$(TargetDir)$(AssemblyName).dll"
       Verbose="true"
       LogFile="$(TargetDir)replacklog.txt"
-      internalize="true" />
+      internalize="true" />-->
 
   </Target>
 

--- a/src/RoslynNunitTestRunner/ErrorProne.NET.TestHelpers.csproj
+++ b/src/RoslynNunitTestRunner/ErrorProne.NET.TestHelpers.csproj
@@ -5,14 +5,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.5.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.NUnit" Version="1.0.1-beta1.20374.2" />
-    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="2.1.0" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.NUnit" Version="1.1.1" />
+    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.3.37" />
+    <PackageReference Update="ILRepack.Lib.MSBuild" Version="2.1.18" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.6.133" />
+    <PackageReference Update="RuntimeContracts" Version="0.5.0" />
   </ItemGroup>
 
 </Project>

--- a/src/global.json
+++ b/src/global.json
@@ -1,9 +1,6 @@
 {
-  "sdk": {
-<<<<<<< Updated upstream
-    "version": "3.1.200"
-=======
-    "version": "5.0.202"
->>>>>>> Stashed changes
-  }
+    "sdk": {
+        "version": "6.0.317",
+        "rollForward": "latestFeature"
+    }
 }


### PR DESCRIPTION
* Update dependencies

* Issue #209 and anonymous usage EPC12 and ERP022

* Fix Traget framework for test projects

* Fix Issue 251 The committed src/global.json is invalid.

* Issue #260 Added som error codes to examples for the error related warnings.