### PR TITLE
Fix IsStructLike to check for value types rather than reference types

### DIFF
--- a/src/ErrorProne.NET.StructAnalyzers/NonDefaultableStructs/NonDefaultableStructsFieldAnalyzer.cs
+++ b/src/ErrorProne.NET.StructAnalyzers/NonDefaultableStructs/NonDefaultableStructsFieldAnalyzer.cs
@@ -76,7 +76,7 @@ namespace ErrorProne.Net.StructAnalyzers.NonDefaultStructs
         private static bool IsStructLike(ITypeSymbol typeSymbol)
         {
             // Extracting logic because it can became more complicated in the future (for instance, with struct records).
-            return typeSymbol.IsReferenceType;
+            return typeSymbol.IsValueType;
         }
 
         private static ITypeSymbol? GetContainingType(PropertyDeclarationSyntax property, SemanticModel model)


### PR DESCRIPTION
@SergeyTeplyakov I'm guessing this was a regression in c0aaebc0eca55d25038c307f2af2ff661e81ac5b.

In 0.3.0 and above I get EPS11 when there's a struct inside a class (which is not a problematic situation) but prior to 0.3.0 I do not.

I was not able to figure out how to build NuGet packages from your source, so I was unable to test this, but you'll know whether or not this is right or not 🙂