### PR TITLE
Implement RPC23

### DIFF
--- a/samples/ErrorProne.Samples/CoreAnalyzers/DefaultContrcutionSample.cs
+++ b/samples/ErrorProne.Samples/CoreAnalyzers/DefaultContrcutionSample.cs
@@ -3,7 +3,6 @@
 [System.AttributeUsage(System.AttributeTargets.Struct)]
 public class NonDefaultableAttribute : System.Attribute { }
 
-
 namespace ErrorProne.Samples.CoreAnalyzers
 {
     [NonDefaultable]

--- a/samples/ErrorProne.Samples/CoreAnalyzers/SetContainsSample.cs
+++ b/samples/ErrorProne.Samples/CoreAnalyzers/SetContainsSample.cs
@@ -135,5 +135,8 @@ public class SetContainsSample
 
         // Not OK: O(N) search!
         r = set.Contains("12", StringComparer.Ordinal);
+
+        var setOfInts = new HashSet<int>();
+        r = setOfInts.Contains(42, EqualityComparer<int>.Default);
     }
 }

--- a/samples/ErrorProne.Samples/CoreAnalyzers/SetContainsSample.cs
+++ b/samples/ErrorProne.Samples/CoreAnalyzers/SetContainsSample.cs
@@ -1,0 +1,139 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System;
+using System.Collections;
+
+namespace ErrorProne.Samples.CoreAnalyzers;
+
+public class SetContainsSample
+{
+    public class MySet<T> : ISet<T>
+    {
+        /// <inheritdoc />
+        public IEnumerator<T> GetEnumerator()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        /// <inheritdoc />
+        void ICollection<T>.Add(T item)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public void ExceptWith(IEnumerable<T> other)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public void IntersectWith(IEnumerable<T> other)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public bool IsProperSubsetOf(IEnumerable<T> other)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public bool IsProperSupersetOf(IEnumerable<T> other)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public bool IsSubsetOf(IEnumerable<T> other)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public bool IsSupersetOf(IEnumerable<T> other)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public bool Overlaps(IEnumerable<T> other)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public bool SetEquals(IEnumerable<T> other)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public void SymmetricExceptWith(IEnumerable<T> other)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public void UnionWith(IEnumerable<T> other)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        bool ISet<T>.Add(T item)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public void Clear()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public bool Contains(T item)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public void CopyTo(T[] array, int arrayIndex)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public bool Remove(T item)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public int Count { get; }
+
+        /// <inheritdoc />
+        public bool IsReadOnly { get; }
+    }
+
+    public void ShowWarnings()
+    {
+        var set = new HashSet<string>();
+        // Ok. O(1) search
+        var r = set.Contains("42");
+        // Ok as well, this overload checks for `ICollection<T>` and calls
+        // Contains(T) to get O(1) search.
+        r = Enumerable.Contains(set, "2");
+
+        // Not OK: O(N) search!
+        r = set.Contains("12", StringComparer.Ordinal);
+    }
+}

--- a/samples/ErrorProne.Samples/ErrorProne.Samples.csproj
+++ b/samples/ErrorProne.Samples/ErrorProne.Samples.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <LangVersion>latest</LangVersion>
     <AssemblyTitle>ErrorProne.Samples</AssemblyTitle>
@@ -10,41 +10,10 @@
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <LangVersion>latest</LangVersion>
     <DebugType>full</DebugType>
+	  <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="1.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="1.1.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="1.1.1" />
-    <PackageReference Include="Rx-Core" Version="2.2.5" />
-    <PackageReference Include="Rx-Interfaces" Version="2.2.5" />
-    <PackageReference Include="Rx-Linq" Version="2.2.5" />
-    <PackageReference Include="Rx-Main" Version="2.2.5" />
-    <PackageReference Include="Rx-PlatformServices" Version="2.2.5" />
-    <PackageReference Include="System.Buffers" Version="4.5.1" />
-    <PackageReference Include="System.Collections" Version="4.0.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.1.37" />
-    <PackageReference Include="System.Diagnostics.Debug" Version="4.0.0" />
-    <PackageReference Include="System.Globalization" Version="4.0.0" />
-    <PackageReference Include="System.IO" Version="4.0.0" />
-    <PackageReference Include="System.Linq" Version="4.0.0" />
-    <PackageReference Include="System.Memory" Version="4.5.4" />
-    <PackageReference Include="System.Reflection" Version="4.0.0" />
-    <PackageReference Include="System.Reflection.Extensions" Version="4.0.0" />
-    <PackageReference Include="System.Reflection.Metadata" Version="1.1.0" />
-    <PackageReference Include="System.Reflection.Primitives" Version="4.0.0" />
-    <PackageReference Include="System.Resources.ResourceManager" Version="4.0.0" />
-    <PackageReference Include="System.Runtime" Version="4.0.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.3" />
-    <PackageReference Include="System.Runtime.Extensions" Version="4.0.0" />
-    <PackageReference Include="System.Runtime.InteropServices" Version="4.0.0" />
-    <PackageReference Include="System.Text.Encoding" Version="4.0.0" />
-    <PackageReference Include="System.Text.Encoding.Extensions" Version="4.0.0" />
-    <PackageReference Include="System.Threading" Version="4.0.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Net.Http" />
+
   </ItemGroup>
 	<ItemGroup>
 		<Analyzer Include="..\..\src\ErrorProne.NET.CoreAnalyzers.CodeFixes\bin\Debug\netstandard2.0\ErrorProne.Net.CoreAnalyzers.CodeFixes.dll" />

--- a/src/ErrorProne.NET.CoreAnalyzers.CodeFixes/ErrorProne.NET.CoreAnalyzers.CodeFixes.csproj
+++ b/src/ErrorProne.NET.CoreAnalyzers.CodeFixes/ErrorProne.NET.CoreAnalyzers.CodeFixes.csproj
@@ -73,6 +73,7 @@
     <ItemGroup>
       <_File Include="$(OutputPath)$(AssemblyName).dll" />
       <_File Include="$(OutputPath)ErrorProne.Net.CoreAnalyzers.dll" />
+      <_File Include="$(OutputPath)RuntimeContracts.dll" />
 
       <TfmSpecificPackageFile Include="@(_File)" PackagePath="analyzers/dotnet/cs/%(_File.RecursiveDir)%(_File.FileName)%(_File.Extension)" />
     </ItemGroup>

--- a/src/ErrorProne.NET.CoreAnalyzers.Tests/AsyncAnalyzers/ThreadUnsafeConcurrentCollectionUsageAnalyzerTests.cs
+++ b/src/ErrorProne.NET.CoreAnalyzers.Tests/AsyncAnalyzers/ThreadUnsafeConcurrentCollectionUsageAnalyzerTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System.Threading.Tasks;
 using VerifyCS = ErrorProne.NET.TestHelpers.CSharpCodeFixVerifier<
     ErrorProne.NET.AsyncAnalyzers.ConcurrentCollectionAnalyzer,

--- a/src/ErrorProne.NET.CoreAnalyzers.Tests/CoreAnalyzers/SetContainsAnalyzerTests.cs
+++ b/src/ErrorProne.NET.CoreAnalyzers.Tests/CoreAnalyzers/SetContainsAnalyzerTests.cs
@@ -1,0 +1,293 @@
+﻿using NUnit.Framework;
+using System.Threading.Tasks;
+using VerifyCS = ErrorProne.NET.TestHelpers.CSharpCodeFixVerifier<
+    ErrorProne.NET.CoreAnalyzers.SetContainsAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using ErrorProne.NET.TestHelpers;
+
+namespace ErrorProne.NET.CoreAnalyzers.Tests.AsyncAnalyzers
+{
+    [TestFixture]
+    public class SetContainsAnalyzerTests
+    {
+        [Test]
+        public async Task No_Warn_On_Enumerable_Contains()
+        {
+            string code = @"
+using System.Collections.Generic;
+using System.Linq;
+public class MyClass
+{
+    private static HashSet<string> cd = new HashSet<string>();
+    public static void Foo(string str)
+    {
+        bool fine = cd.Contains(str);
+        bool notFine = System.Linq.Enumerable.Contains(cd, str);
+    }
+
+}";
+
+            await new VerifyCS.Test
+            {
+                TestState = { Sources = { code } }
+            }.WithoutGeneratedCodeVerification().RunAsync();
+        }
+        
+        [Test]
+        public async Task Warn_On_Enumerable_Contains_With_Parameter()
+        {
+            string code = @"
+using System.Collections.Generic;
+using System.Linq;
+public class MyClass
+{
+    public static void Foo(HashSet<string> cd, string str)
+    {
+        bool fine = cd.Contains(str);
+        bool notFine = [|cd.Contains(str, System.StringComparer.Ordinal)|];
+    }
+
+}";
+
+            await new VerifyCS.Test
+            {
+                TestState = { Sources = { code } }
+            }.WithoutGeneratedCodeVerification().RunAsync();
+        }
+        
+        [Test]
+        public async Task Warn_On_Enumerable_Contains_With_Local()
+        {
+            string code = @"
+using System.Collections.Generic;
+using System.Linq;
+public class MyClass
+{
+    public static void Foo(string str)
+    {
+        HashSet<string> cd = new HashSet<string>();
+        bool fine = cd.Contains(str);
+        bool notFine = [|cd.Contains(str, System.StringComparer.Ordinal)|];
+    }
+
+}";
+
+            await new VerifyCS.Test
+            {
+                TestState = { Sources = { code } }
+            }.WithoutGeneratedCodeVerification().RunAsync();
+        }
+        
+        [Test]
+        public async Task Warn_On_HashSet_Of_String_With_Extension_Method_Contains()
+        {
+            string code = @"
+using System.Collections.Generic;
+using System.Linq;
+public class MyClass
+{
+    private static HashSet<string> cd = new HashSet<string>();
+    public static void Foo(string str)
+    {
+        bool fine = cd.Contains(str);
+        bool notFine = [|System.Linq.Enumerable.Contains(cd, str, System.StringComparer.Ordinal)|];
+    }
+
+}";
+
+            await new VerifyCS.Test
+            {
+                TestState = { Sources = { code } }
+            }.WithoutGeneratedCodeVerification().RunAsync();
+        }
+        
+        [Test]
+        public async Task Warn_On_HashSet_Of_String_Contains_And_StringComparison()
+        {
+            string code = @"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+public class MyClass
+{
+    private static HashSet<string> cd = new HashSet<string>();
+    public static void Foo(string str)
+    {
+        bool fine = cd.Contains(str);
+        bool notFine = [|cd.Contains(str, StringComparer.CurrentCulture)|];
+    }
+}";
+
+            await new VerifyCS.Test
+            {
+                TestState = { Sources = { code } }
+            }.WithoutGeneratedCodeVerification().RunAsync();
+        }
+        
+        [Test]
+        public async Task Warn_On_ISet_Of_String_With_Extension_Method_Contains()
+        {
+            string code = @"
+using System.Collections.Generic;
+using System.Linq;
+public class MyClass
+{
+    private static ISet<string> cd = new HashSet<string>();
+    public static void Foo(string str)
+    {
+        bool fine = cd.Contains(str);
+        bool notFine = [|System.Linq.Enumerable.Contains(cd, str, System.StringComparer.Ordinal)|];
+    }
+
+}";
+
+            await new VerifyCS.Test
+            {
+                TestState = { Sources = { code } }
+            }.WithoutGeneratedCodeVerification().RunAsync();
+        }
+        
+        [Test]
+        public async Task Warn_On_CustomSet()
+        {
+            string code = @"
+using System.Collections.Generic;
+using System.Linq;
+using System;
+using System.Collections;
+
+public class MySet<T> : ISet<T>
+    {
+        /// <inheritdoc />
+        public IEnumerator<T> GetEnumerator()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        /// <inheritdoc />
+        void ICollection<T>.Add(T item)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public void ExceptWith(IEnumerable<T> other)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public void IntersectWith(IEnumerable<T> other)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public bool IsProperSubsetOf(IEnumerable<T> other)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public bool IsProperSupersetOf(IEnumerable<T> other)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public bool IsSubsetOf(IEnumerable<T> other)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public bool IsSupersetOf(IEnumerable<T> other)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public bool Overlaps(IEnumerable<T> other)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public bool SetEquals(IEnumerable<T> other)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public void SymmetricExceptWith(IEnumerable<T> other)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public void UnionWith(IEnumerable<T> other)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        bool ISet<T>.Add(T item)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public void Clear()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public bool Contains(T item)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public void CopyTo(T[] array, int arrayIndex)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public bool Remove(T item)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public int Count { get; }
+
+        /// <inheritdoc />
+        public bool IsReadOnly { get; }
+    }
+
+public class MyClass
+{
+    private static MySet<string> cd = new MySet<string>();
+    public static void Foo(string str)
+    {
+        bool fine = cd.Contains(str);
+        bool notFine = [|System.Linq.Enumerable.Contains(cd, str, StringComparer.Ordinal)|];
+    }
+
+}";
+
+            await new VerifyCS.Test
+            {
+                TestState = { Sources = { code } }
+            }.WithoutGeneratedCodeVerification().RunAsync();
+        }
+    }
+}

--- a/src/ErrorProne.NET.CoreAnalyzers.Tests/CoreAnalyzers/SetContainsAnalyzerTests.cs
+++ b/src/ErrorProne.NET.CoreAnalyzers.Tests/CoreAnalyzers/SetContainsAnalyzerTests.cs
@@ -56,6 +56,28 @@ public class MyClass
         }
         
         [Test]
+        public async Task Warn_On_Enumerable_Contains_For_HashSet_Of_int()
+        {
+            string code = @"
+using System.Collections.Generic;
+using System.Linq;
+public class MyClass
+{
+    public static void Foo(HashSet<int> cd, int str)
+    {
+        bool fine = cd.Contains(str);
+        bool notFine = [|cd.Contains(str, EqualityComparer<int>.Default)|];
+    }
+
+}";
+
+            await new VerifyCS.Test
+            {
+                TestState = { Sources = { code } }
+            }.WithoutGeneratedCodeVerification().RunAsync();
+        }
+        
+        [Test]
         public async Task Warn_On_Enumerable_Contains_With_Local()
         {
             string code = @"

--- a/src/ErrorProne.NET.CoreAnalyzers/AnalyzerReleases.Unshipped.md
+++ b/src/ErrorProne.NET.CoreAnalyzers/AnalyzerReleases.Unshipped.md
@@ -14,6 +14,7 @@ EPC17 | CodeSmell | Warning | AsyncVoidLambdaAnalyzer
 EPC18 | CodeSmell | Warning | TaskInstanceToStringConversionAnalyzer
 EPC19 | CodeSmell | Warning | CancellationTokenRegistrationAnalyzer
 EPC20 | CodeSmell | Warning | DefaultToStringImplementationUsageAnalyzer
+EPC23 | Performance | Warning | HashSetContainsAnalyzer
 ERP021 | CodeSmell | Warning | ThrowExAnalyzer
 ERP022 | CodeSmell | Warning | SwallowAllExceptionsAnalyzer
 ERP031 | Concurrency | Warning | ConcurrentCollectionAnalyzer

--- a/src/ErrorProne.NET.CoreAnalyzers/CoreAnalyzers/SetContainsAnalyzer.cs
+++ b/src/ErrorProne.NET.CoreAnalyzers/CoreAnalyzers/SetContainsAnalyzer.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using ErrorProne.NET.Core;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace ErrorProne.NET.CoreAnalyzers
+{
+    /// <summary>
+    /// An analyzer that warns about incorrect usage of concurrent collection types.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class SetContainsAnalyzer : DiagnosticAnalyzerBase
+    {
+        /// <nodoc />
+        public static DiagnosticDescriptor Rule => DiagnosticDescriptors.EPC23;
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        /// <nodoc />
+        public SetContainsAnalyzer()
+            : base(Rule)
+        {
+        }
+
+        /// <inheritdoc />
+        protected override void InitializeCore(AnalysisContext context)
+        {
+            context.RegisterOperationAction(AnalyzeInvocationOperation, OperationKind.Invocation);
+        }
+
+        private void AnalyzeInvocationOperation(OperationAnalysisContext context)
+        {
+            try
+            {
+                // Detecting the calls to concurrentDictionaryInstance.OrderBy because
+                // it may fail with ArgumentException if the collection is being mutated concurrently at the same time.
+                var invocationOperation = (IInvocationOperation)context.Operation;
+
+                var receiverType = invocationOperation.GetReceiverType(includeLocal: true);
+                
+                if (
+                    IsEnumerableContains(invocationOperation.TargetMethod, context.Compilation) &&
+                    IsSet(receiverType, context.Compilation))
+                {
+                    var diagnostic = Diagnostic.Create(Rule, invocationOperation.Syntax.GetLocation());
+                    context.ReportDiagnostic(diagnostic);
+                }
+            }
+            catch (Exception)
+            {
+                throw;
+                //Debugger.Launch();
+                //throw new Exception(e.StackTrace);
+            }
+
+            static bool IsEnumerableContains(IMethodSymbol methodSymbol, Compilation compilation)
+            {
+                return methodSymbol.Name == nameof(Enumerable.Contains) &&
+                       // There are two overloads, one that just takes the value
+                       // and the second one that takes StringComparer,
+                       // and only the second one is linear.
+                       methodSymbol.Parameters.Length == 3 &&
+                       methodSymbol.ContainingType.IsClrType(compilation, typeof(System.Linq.Enumerable));
+            }
+
+            static bool IsSet(ITypeSymbol? typeSymbol, Compilation compilation)
+            {
+                if (typeSymbol == null || typeSymbol is not INamedTypeSymbol nt || !nt.IsGenericType)
+                {
+                    return false;
+                }
+
+                return typeSymbol.IsGenericType(compilation, typeof(HashSet<>)) ||
+                       typeSymbol.IsGenericType(compilation, typeof(ISet<>)) ||
+                       (typeSymbol as INamedTypeSymbol)
+                           ?.ConstructedFrom
+                           .AllInterfaces
+                           .Any(i => i.IsGenericType(compilation, typeof(ISet<>))) == true;
+            }
+        }
+    }
+}

--- a/src/ErrorProne.NET.CoreAnalyzers/CoreAnalyzers/SetContainsAnalyzer.cs
+++ b/src/ErrorProne.NET.CoreAnalyzers/CoreAnalyzers/SetContainsAnalyzer.cs
@@ -69,7 +69,7 @@ namespace ErrorProne.NET.CoreAnalyzers
 
             static bool IsSet(ITypeSymbol? typeSymbol, Compilation compilation)
             {
-                if (typeSymbol == null || typeSymbol is not INamedTypeSymbol nt || !nt.IsGenericType)
+                if (typeSymbol is not INamedTypeSymbol { IsGenericType: true } nt)
                 {
                     return false;
                 }

--- a/src/ErrorProne.NET.CoreAnalyzers/DiagnosticDescriptors.cs
+++ b/src/ErrorProne.NET.CoreAnalyzers/DiagnosticDescriptors.cs
@@ -8,6 +8,7 @@ namespace ErrorProne.NET
     internal static class DiagnosticDescriptors
     {
         private const string CodeSmellCategory = "CodeSmell";
+        private const string PerformanceCategory = "Performance";
         private const string ConcurrencyCategory = "Concurrency";
         private static readonly string[] UnnecessaryTag = new [] { WellKnownDiagnosticTags.Unnecessary };
 
@@ -111,6 +112,14 @@ namespace ErrorProne.NET
             messageFormat: "An exit point '{0}' swallows an unobserved exception", 
             CodeSmellCategory, DiagnosticSeverity.Warning, isEnabledByDefault: true, 
             description: "A generic catch block swallows an exception that was not observed.");
+        
+        /// <nodoc />
+        internal static readonly DiagnosticDescriptor EPC23 = new DiagnosticDescriptor(
+            nameof(EPC23), 
+            title: "Avoid using Enumerable.Contains on HashSet<string>", 
+            messageFormat: "Linear search via Enumerable.Contains is used instead of an instance Contains method", 
+            PerformanceCategory, DiagnosticSeverity.Warning, isEnabledByDefault: true, 
+            description: "Enumerable.Contains is less efficient since it scans all the entries in the hashset and allocates an iterator.");
 
         /// <nodoc />
         public static readonly DiagnosticDescriptor ERP031 = new DiagnosticDescriptor(

--- a/src/ErrorProne.NET.CoreAnalyzers/DiagnosticDescriptors.cs
+++ b/src/ErrorProne.NET.CoreAnalyzers/DiagnosticDescriptors.cs
@@ -116,7 +116,7 @@ namespace ErrorProne.NET
         /// <nodoc />
         internal static readonly DiagnosticDescriptor EPC23 = new DiagnosticDescriptor(
             nameof(EPC23), 
-            title: "Avoid using Enumerable.Contains on HashSet<string>", 
+            title: "Avoid using Enumerable.Contains on HashSet<T>", 
             messageFormat: "Linear search via Enumerable.Contains is used instead of an instance Contains method", 
             PerformanceCategory, DiagnosticSeverity.Warning, isEnabledByDefault: true, 
             description: "Enumerable.Contains is less efficient since it scans all the entries in the hashset and allocates an iterator.");

--- a/src/ErrorProne.NET.CoreAnalyzers/ErrorProne.NET.CoreAnalyzers.csproj
+++ b/src/ErrorProne.NET.CoreAnalyzers/ErrorProne.NET.CoreAnalyzers.csproj
@@ -5,7 +5,29 @@
     <AssemblyName>ErrorProne.Net.CoreAnalyzers</AssemblyName>
     <RootNamespace>ErrorProne.NET</RootNamespace>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <!--<DoILRepack>true</DoILRepack>-->
+    <EmbedRuntimeContracts>true</EmbedRuntimeContracts>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\ErrorProne.NET.Core\AnalyzerConfigOptionsExtensions.cs" Link="AnalyzerConfigOptionsExtensions.cs" />
+    <Compile Include="..\ErrorProne.NET.Core\BodySyntaxExtensions.cs" Link="BodySyntaxExtensions.cs" />
+    <Compile Include="..\ErrorProne.NET.Core\CastUtilities.cs" Link="CastUtilities.cs" />
+    <Compile Include="..\ErrorProne.NET.Core\CompilationExtensions.cs" Link="CompilationExtensions.cs" />
+    <Compile Include="..\ErrorProne.NET.Core\DiagnosticAnalyzerBase.cs" Link="DiagnosticAnalyzerBase.cs" />
+    <Compile Include="..\ErrorProne.NET.Core\ErrorProneAttributes.cs" Link="ErrorProneAttributes.cs" />
+    <Compile Include="..\ErrorProne.NET.Core\FlowAnalysisExtensions.cs" Link="FlowAnalysisExtensions.cs" />
+    <Compile Include="..\ErrorProne.NET.Core\MethodDeclarationSyntaxExtensions.cs" Link="MethodDeclarationSyntaxExtensions.cs" />
+    <Compile Include="..\ErrorProne.NET.Core\NamedSymbolExtensions.cs" Link="NamedSymbolExtensions.cs" />
+    <Compile Include="..\ErrorProne.NET.Core\StructSizeCalculator.cs" Link="StructSizeCalculator.cs" />
+    <Compile Include="..\ErrorProne.NET.Core\SymbolAnalysisContextExtensions.cs" Link="SymbolAnalysisContextExtensions.cs" />
+    <Compile Include="..\ErrorProne.NET.Core\SymbolExtensions.cs" Link="SymbolExtensions.cs" />
+    <Compile Include="..\ErrorProne.NET.Core\SyntaxFactoryExtensions.cs" Link="SyntaxFactoryExtensions.cs" />
+    <Compile Include="..\ErrorProne.NET.Core\SyntaxNodeExtensions.cs" Link="SyntaxNodeExtensions.cs" />
+    <Compile Include="..\ErrorProne.NET.Core\TypeExtensions.cs" Link="TypeExtensions.cs" />
+    <Compile Include="..\ErrorProne.NET.Core\ValueTypeEqualityImplementations.cs" Link="ValueTypeEqualityImplementations.cs" />
+    <Compile Include="..\ErrorProne.NET.Core\WellKnownTypesProvider.cs" Link="WellKnownTypesProvider.cs" />
+  </ItemGroup>
 
   <!--
       Instead of splitting the code into a separate dll, just reference it as the source code.
@@ -13,7 +35,6 @@
       incompatible changes on the "core" level
    -->
   <ItemGroup>
-    <Compile Include="..\ErrorProne.NET.Core\**.cs" Label="Core" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="4.6.0" />
   </ItemGroup>
 
@@ -34,5 +55,40 @@
     <PackageReference Update="Nerdbank.GitVersioning" Version="3.6.133" />
     <PackageReference Update="RuntimeContracts" Version="0.5.0" />
   </ItemGroup>
+
+  <!--<Target Name="ILRepack" AfterTargets="Build">
+    <ItemGroup>
+      <InputAssemblies Include="$(OutputPath)$(AssemblyName).dll" />
+      --><!--<InputAssemblies Include="$(OutputPath)RuntimeContracts.dll" />--><!--
+       --><!--Add more dependencies as needed--><!-- 
+    </ItemGroup>
+    --><!--<ILRepack OutputType="Library"  />--><!--
+  </Target>-->
+
+
+  <!--<Target Name="ILRepacker" AfterTargets="Build" >
+    <ItemGroup>
+      <InputAssemblies Include="$(TargetPath)"/>
+      <InputAssemblies Include="@(ReferencePathWithRefAssemblies)" Condition="'%(filename)' == 'RuntimeContracts'" />
+    </ItemGroup>
+
+    <ILRepack
+        AllowDuplicateResources="false"
+        DebugInfo="true"
+        Internalize="true"
+        InputAssemblies="@(InputAssemblies)"
+        OutputFile="$(TargetPath)"
+        Parallel="true"
+        TargetKind="SameAsPrimaryAssembly" />
+  </Target>-->
+
+  <!--<Target Name="_GetFilesToPackage">
+    <ItemGroup>
+      <_File Include="$(OutputPath)$(AssemblyName).dll" />
+      --><!--<_File Include="$(OutputPath)RuntimeContracts.dll" />--><!--
+
+      <TfmSpecificPackageFile Include="@(_File)" PackagePath="analyzers/dotnet/cs/%(_File.RecursiveDir)%(_File.FileName)%(_File.Extension)" />
+    </ItemGroup>
+  </Target>-->
   
 </Project>

--- a/src/ILRepack.targets
+++ b/src/ILRepack.targets
@@ -7,23 +7,21 @@
     <ItemGroup>
       <InputAssemblies Include="$(TargetPath)"/>
       <InputAssemblies Include="$(PkgRuntimeContracts)\lib\netstandard1.1\RuntimeContracts.dll" />
-      <!-- <InputAssemblies Include="$(TargetDir)\ErrorProne.NET.Core.dll" Condition="$(AssemblyName) != 'ErrorProne.NET.Core'" /> -->
     </ItemGroup>
     <ItemGroup>
       <!-- Dot not internalize any types inside this assembly -->
       <!--<InternalizeExcludeAssemblies Include="RuntimeContracts" />-->
     </ItemGroup>
     <Message Text="MERGING: @(InputAssemblies->'%(Filename)') into $(OutputAssembly)" Importance="High" />
-    <!--<ILRepack 
-      Parallel="true"
-      DebugInfo="true"
-      InputAssemblies="@(InputAssemblies)"
-      TargetKind="SameAsPrimaryAssembly"
-      OutputFile="$(TargetDir)$(AssemblyName).dll"
-      Verbose="true"
-      LogFile="$(TargetDir)replacklog.txt"
-      internalize="true" />-->
-
+<ILRepack
+    AllowDuplicateResources="false"
+    DebugInfo="true"
+    Internalize="true"
+    InputAssemblies="@(InputAssemblies)"
+    OutputFile="$(TargetPath)"
+    Parallel="true"
+    LogFile="$(TargetDir)replacklog.txt"
+    TargetKind="SameAsPrimaryAssembly" />
   </Target>
 
 </Project>


### PR DESCRIPTION
Implements 'Avoid using Enumerable.Contains on HashSet<string>' analyzer.

Here is an example:

<img width="452" alt="image" src="https://github.com/SergeyTeplyakov/ErrorProne.NET/assets/726448/ab171695-0a6c-4718-8db0-d7b6636b2344">
