### PR TITLE
Fix MakeStructReadOnlyanalyzer crash

### DIFF
--- a/src/ErrorProne.NET.Core/SyntaxNodeExtensions.cs
+++ b/src/ErrorProne.NET.Core/SyntaxNodeExtensions.cs
@@ -45,7 +45,7 @@ namespace ErrorProne.NET.Extensions
         
         public static bool MarkedWithReadOnlyModifier(this IPropertySymbol property)
         {
-            return property
+            return property.IsReadOnly && property
                 .DeclaringSyntaxReferences
                 .Select(p => (BasePropertyDeclarationSyntax)p.GetSyntax())
                 .Any(p => MarkedWithReadOnlyModifier(p));

--- a/src/ErrorProne.NET.StructAnalyzers.Tests/MakeStructReadOnlyAnalyzerTests.cs
+++ b/src/ErrorProne.NET.StructAnalyzers.Tests/MakeStructReadOnlyAnalyzerTests.cs
@@ -280,6 +280,13 @@ this = other;
         }
 
         [Test]
+        public async Task NoDiagnosticRecordStruct()
+        {
+            string code = @"public record struct ItemGroup(int Amount);";
+            await VerifyCS.VerifyAnalyzerAsync(code);
+        }
+
+        [Test]
         public async Task NoDiagnosticCasesWhenStructIsAlreadyReadonlyWithPartialDeclaration()
         {
             string code = @"partial struct FooBar {} readonly partial struct FooBar {}";


### PR DESCRIPTION
When the property symbol comes from a record primary constructor (i.e, associated with ParameterSyntax), the property will have property.IsReadOnly = false, which would avoid the invalid cast to `BasePropertyDeclarationSyntax`.