### PR TITLE
Cleanup tests by using VerifyCS

### DIFF
--- a/src/ErrorProne.NET.Core/AnalyzerConfigOptionsExtensions.cs
+++ b/src/ErrorProne.NET.Core/AnalyzerConfigOptionsExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace ErrorProne.NET.Core

--- a/src/ErrorProne.NET.Core/ErrorProneAttributes.cs
+++ b/src/ErrorProne.NET.Core/ErrorProneAttributes.cs
@@ -1,9 +1,5 @@
-﻿using System;
-
-namespace ErrorProne.NET.Core.Attributes
+﻿namespace ErrorProne.NET.Core.Attributes
 {
-    [AttributeUsage(AttributeTargets.Assembly)]
-    public class UseConfigureAwaitFalseAttribute : Attribute
-    {
-    }
+    [System.AttributeUsage(System.AttributeTargets.Assembly)]
+    public class UseConfigureAwaitFalseAttribute : System.Attribute { }
 }

--- a/src/ErrorProne.NET.CoreAnalyzers.CodeFixes/AsyncAnalyzers/RemoveConfigureAwaitCodeFixProvider.cs
+++ b/src/ErrorProne.NET.CoreAnalyzers.CodeFixes/AsyncAnalyzers/RemoveConfigureAwaitCodeFixProvider.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Composition;
 using System.Diagnostics;
 using System.Linq;

--- a/src/ErrorProne.NET.CoreAnalyzers.Tests/AsyncAnalyzers/AddConfigureAwaitAnalyzerTests.cs
+++ b/src/ErrorProne.NET.CoreAnalyzers.Tests/AsyncAnalyzers/AddConfigureAwaitAnalyzerTests.cs
@@ -1,6 +1,4 @@
-﻿using ErrorProne.NET.AsyncAnalyzers;
-using ErrorProne.NET.TestHelpers;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System.Threading.Tasks;
 using VerifyCS = ErrorProne.NET.TestHelpers.CSharpCodeFixVerifier<
     ErrorProne.NET.AsyncAnalyzers.ConfigureAwaitRequiredAnalyzer,
@@ -17,25 +15,18 @@ namespace ErrorProne.NET.CoreAnalyzers.Tests.AsyncAnalyzers
             string code = @"
 [assembly:UseConfigureAwaitFalse()]
 
+[System.AttributeUsage(System.AttributeTargets.Assembly)]
+public class UseConfigureAwaitFalseAttribute : System.Attribute { }
+
 public class MyClass
 {
     public static async System.Threading.Tasks.Task Foo()
     {
-       await System.Threading.Tasks.Task.Delay(42);
+       [|await System.Threading.Tasks.Task.Delay(42)|];
     }
 }
 ";
-            await new VerifyCS.Test
-            {
-                TestState =
-                {
-                    Sources = { code },
-                    ExpectedDiagnostics =
-                    {
-                        VerifyCS.Diagnostic(ConfigureAwaitRequiredAnalyzer.Rule).WithSpan(8, 8, 8, 51),
-                    },
-                },
-            }.WithoutGeneratedCodeVerification().WithConfigureAwaitAttributes().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
 
         [Test]
@@ -43,6 +34,9 @@ public class MyClass
         {
             string code = @"
 [assembly:UseConfigureAwaitFalse()]
+
+[System.AttributeUsage(System.AttributeTargets.Assembly)]
+public class UseConfigureAwaitFalseAttribute : System.Attribute { }
 
 public class MyClass
 {
@@ -52,10 +46,7 @@ public class MyClass
     }
 }
 ";
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } },
-            }.WithoutGeneratedCodeVerification().WithConfigureAwaitAttributes().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
 
         [Test]
@@ -64,26 +55,19 @@ public class MyClass
             string code = @"
 [assembly:UseConfigureAwaitFalse()]
 
+[System.AttributeUsage(System.AttributeTargets.Assembly)]
+public class UseConfigureAwaitFalseAttribute : System.Attribute { }
+
 public class MyClass
 {
     private static System.Threading.Tasks.Task MyTask => null;
     public static async System.Threading.Tasks.Task Foo()
     {
-       await MyTask;
+       [|await MyTask|];
     }
 }
 ";
-            await new VerifyCS.Test
-            {
-                TestState =
-                {
-                    Sources = { code },
-                    ExpectedDiagnostics =
-                    {
-                        VerifyCS.Diagnostic(ConfigureAwaitRequiredAnalyzer.Rule).WithSpan(9, 8, 9, 20),
-                    },
-                },
-            }.WithoutGeneratedCodeVerification().WithConfigureAwaitAttributes().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
     }
 }

--- a/src/ErrorProne.NET.CoreAnalyzers.Tests/AsyncAnalyzers/AddConfigureAwaitCodeFixProviderTests.cs
+++ b/src/ErrorProne.NET.CoreAnalyzers.Tests/AsyncAnalyzers/AddConfigureAwaitCodeFixProviderTests.cs
@@ -1,6 +1,4 @@
-﻿using ErrorProne.NET.AsyncAnalyzers;
-using ErrorProne.NET.TestHelpers;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System.Threading.Tasks;
 using VerifyCS = ErrorProne.NET.TestHelpers.CSharpCodeFixVerifier<
     ErrorProne.NET.AsyncAnalyzers.ConfigureAwaitRequiredAnalyzer,
@@ -16,16 +14,24 @@ namespace ErrorProne.NET.CoreAnalyzers.Tests.AsyncAnalyzers
         {
             string code = @"
 [assembly:UseConfigureAwaitFalse()]
+
+[System.AttributeUsage(System.AttributeTargets.Assembly)]
+public class UseConfigureAwaitFalseAttribute : System.Attribute { }
+
 public class MyClass
 {
     public static async System.Threading.Tasks.Task Foo()
     {
-       await System.Threading.Tasks.Task.Delay(42);
+       [|await System.Threading.Tasks.Task.Delay(42)|];
     }
 }";
 
             string expected = @"
 [assembly:UseConfigureAwaitFalse()]
+
+[System.AttributeUsage(System.AttributeTargets.Assembly)]
+public class UseConfigureAwaitFalseAttribute : System.Attribute { }
+
 public class MyClass
 {
     public static async System.Threading.Tasks.Task Foo()
@@ -33,22 +39,7 @@ public class MyClass
        await System.Threading.Tasks.Task.Delay(42).ConfigureAwait(false);
     }
 }";
-
-            await new VerifyCS.Test
-            {
-                TestState =
-                {
-                    Sources = { code },
-                    ExpectedDiagnostics =
-                    {
-                        VerifyCS.Diagnostic(ConfigureAwaitRequiredAnalyzer.Rule).WithSpan(7, 8, 7, 51),
-                    },
-                },
-                FixedState =
-                {
-                    Sources = { expected },
-                },
-            }.WithoutGeneratedCodeVerification().WithConfigureAwaitAttributes().RunAsync();
+            await VerifyCS.VerifyCodeFixAsync(code, expected);
         }
     }
 }

--- a/src/ErrorProne.NET.CoreAnalyzers.Tests/AsyncAnalyzers/CancellationTokenRegistrationAnalyzerTests.cs
+++ b/src/ErrorProne.NET.CoreAnalyzers.Tests/AsyncAnalyzers/CancellationTokenRegistrationAnalyzerTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Threading;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System.Threading.Tasks;
 using Verify = ErrorProne.NET.TestHelpers.CSharpCodeFixVerifier<
     ErrorProne.NET.AsyncAnalyzers.CancellationTokenRegistrationAnalyzer,

--- a/src/ErrorProne.NET.CoreAnalyzers.Tests/AsyncAnalyzers/NullConditionalOperatorAnalyzerTests.cs
+++ b/src/ErrorProne.NET.CoreAnalyzers.Tests/AsyncAnalyzers/NullConditionalOperatorAnalyzerTests.cs
@@ -1,5 +1,4 @@
-﻿using ErrorProne.NET.TestHelpers;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System.Threading.Tasks;
 using VerifyCS = ErrorProne.NET.TestHelpers.CSharpCodeFixVerifier<
     ErrorProne.NET.AsyncAnalyzers.NullConditionalOperatorAnalyzer,
@@ -22,11 +21,7 @@ public class MyClass
     }
 }
 ";
-
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } }
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
    }
 }

--- a/src/ErrorProne.NET.CoreAnalyzers.Tests/AsyncAnalyzers/RemoveConfigureAwaitAnalyzerTests.cs
+++ b/src/ErrorProne.NET.CoreAnalyzers.Tests/AsyncAnalyzers/RemoveConfigureAwaitAnalyzerTests.cs
@@ -1,7 +1,4 @@
-﻿using ErrorProne.NET.AsyncAnalyzers;
-using ErrorProne.NET.TestHelpers;
-using Microsoft.CodeAnalysis;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System.Threading.Tasks;
 using VerifyCS = ErrorProne.NET.TestHelpers.CSharpCodeFixVerifier<
     ErrorProne.NET.AsyncAnalyzers.RedundantConfigureAwaitFalseAnalyzer,
@@ -18,25 +15,18 @@ namespace ErrorProne.NET.CoreAnalyzers.Tests.AsyncAnalyzers
             string code = @"
 [assembly:DoNotUseConfigureAwait()]
 
+[System.AttributeUsage(System.AttributeTargets.Assembly)]
+public class DoNotUseConfigureAwait : System.Attribute { }
+
 public class MyClass
 {
     public static async System.Threading.Tasks.Task Foo()
     {
-       await System.Threading.Tasks.Task.Delay(42).ConfigureAwait(false);
+       await System.Threading.Tasks.Task.Delay(42).[|ConfigureAwait(false)|];
     }
 }
 ";
-            await new VerifyCS.Test
-            {
-                TestState =
-                {
-                    Sources = { code },
-                    ExpectedDiagnostics =
-                    {
-                        VerifyCS.Diagnostic(RedundantConfigureAwaitFalseAnalyzer.Rule).WithSpan(8, 52, 8, 73),
-                    },
-                },
-            }.WithoutGeneratedCodeVerification().WithConfigureAwaitAttributes().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
 
         [Test]
@@ -45,26 +35,20 @@ public class MyClass
             string code = @"
 [assembly:DoNotUseConfigureAwait()]
 
+[System.AttributeUsage(System.AttributeTargets.Assembly)]
+public class DoNotUseConfigureAwait : System.Attribute { }
+
 public class MyClass
 {
     private static System.Threading.Tasks.Task MyTask => null;
     public static async System.Threading.Tasks.Task Foo()
     {
-       await MyTask.ConfigureAwait(false);
+       await MyTask.[|ConfigureAwait(false)|];
     }
 }
 ";
-            await new VerifyCS.Test
-            {
-                TestState =
-                {
-                    Sources = { code },
-                    ExpectedDiagnostics =
-                    {
-                        VerifyCS.Diagnostic(RedundantConfigureAwaitFalseAnalyzer.Rule).WithSpan(9, 21, 9, 42),
-                    },
-                },
-            }.WithoutGeneratedCodeVerification().WithConfigureAwaitAttributes().RunAsync();
+
+            await VerifyCS.VerifyAsync(code);
         }
     }
 }

--- a/src/ErrorProne.NET.CoreAnalyzers.Tests/AsyncAnalyzers/RemoveConfigureAwaitCodeFixProviderTests.cs
+++ b/src/ErrorProne.NET.CoreAnalyzers.Tests/AsyncAnalyzers/RemoveConfigureAwaitCodeFixProviderTests.cs
@@ -1,7 +1,4 @@
-﻿using ErrorProne.NET.AsyncAnalyzers;
-using ErrorProne.NET.TestHelpers;
-using Microsoft.CodeAnalysis;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System.Threading.Tasks;
 using VerifyCS = ErrorProne.NET.TestHelpers.CSharpCodeFixVerifier<
     ErrorProne.NET.AsyncAnalyzers.RedundantConfigureAwaitFalseAnalyzer,
@@ -17,16 +14,24 @@ namespace ErrorProne.NET.CoreAnalyzers.Tests.AsyncAnalyzers
         {
             string code = @"
 [assembly:DoNotUseConfigureAwait()]
+
+[System.AttributeUsage(System.AttributeTargets.Assembly)]
+public class DoNotUseConfigureAwait : System.Attribute { }
+
 public class MyClass
 {
     public static async System.Threading.Tasks.Task Foo()
     {
-       await System.Threading.Tasks.Task.Delay(42).ConfigureAwait(false);
+       await System.Threading.Tasks.Task.Delay(42).[|ConfigureAwait(false)|];
     }
 }";
 
             string expected = @"
 [assembly:DoNotUseConfigureAwait()]
+
+[System.AttributeUsage(System.AttributeTargets.Assembly)]
+public class DoNotUseConfigureAwait : System.Attribute { }
+
 public class MyClass
 {
     public static async System.Threading.Tasks.Task Foo()
@@ -35,21 +40,7 @@ public class MyClass
     }
 }";
 
-            await new VerifyCS.Test
-            {
-                TestState =
-                {
-                    Sources = { code },
-                    ExpectedDiagnostics =
-                    {
-                        VerifyCS.Diagnostic(RedundantConfigureAwaitFalseAnalyzer.Rule).WithSpan(7, 52, 7, 73),
-                    },
-                },
-                FixedState =
-                {
-                    Sources = { expected },
-                },
-            }.WithoutGeneratedCodeVerification().WithConfigureAwaitAttributes().RunAsync();
+            await VerifyCS.VerifyCodeFixAsync(code, expected);
         }
 
         [Test]
@@ -57,17 +48,25 @@ public class MyClass
         {
             string code = @"
 [assembly:DoNotUseConfigureAwait()]
+
+[System.AttributeUsage(System.AttributeTargets.Assembly)]
+public class DoNotUseConfigureAwait : System.Attribute { }
+
 public class MyClass
 {
     public static async System.Threading.Tasks.Task Foo()
     {
        await System.Threading.Tasks.Task.Delay(42)
-         .ConfigureAwait(false);
+         .[|ConfigureAwait(false)|];
     }
 }";
 
             string expected = @"
 [assembly:DoNotUseConfigureAwait()]
+
+[System.AttributeUsage(System.AttributeTargets.Assembly)]
+public class DoNotUseConfigureAwait : System.Attribute { }
+
 public class MyClass
 {
     public static async System.Threading.Tasks.Task Foo()
@@ -76,21 +75,7 @@ public class MyClass
     }
 }";
 
-            await new VerifyCS.Test
-            {
-                TestState =
-                {
-                    Sources = { code },
-                    ExpectedDiagnostics =
-                    {
-                        VerifyCS.Diagnostic(RedundantConfigureAwaitFalseAnalyzer.Rule).WithSpan(8, 11, 8, 32),
-                    },
-                },
-                FixedState =
-                {
-                    Sources = { expected },
-                },
-            }.WithoutGeneratedCodeVerification().WithConfigureAwaitAttributes().RunAsync();
+            await VerifyCS.VerifyCodeFixAsync(code, expected);
         }
     }
 }

--- a/src/ErrorProne.NET.CoreAnalyzers.Tests/AsyncAnalyzers/ThreadUnsafeConcurrentCollectionUsageAnalyzerTests.cs
+++ b/src/ErrorProne.NET.CoreAnalyzers.Tests/AsyncAnalyzers/ThreadUnsafeConcurrentCollectionUsageAnalyzerTests.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using VerifyCS = ErrorProne.NET.TestHelpers.CSharpCodeFixVerifier<
     ErrorProne.NET.AsyncAnalyzers.ConcurrentCollectionAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
-using ErrorProne.NET.TestHelpers;
 
 namespace ErrorProne.NET.CoreAnalyzers.Tests.AsyncAnalyzers
 {
@@ -25,11 +24,7 @@ public class MyClass
        sequence = [|cd.OrderByDescending(kvp => kvp.Key)|];
     }
 }";
-
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } }
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
         
         [Test]
@@ -47,10 +42,7 @@ public class MyClass
     }
 }";
 
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } }
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
         
         [Test]
@@ -68,10 +60,7 @@ public class MyClass
     }
 }";
 
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } }
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
         
         [Test]
@@ -92,10 +81,7 @@ public class MyClass
     }
 }";
 
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } }
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
         
         [Test]
@@ -119,10 +105,7 @@ public class MyClass
     }
 }";
 
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } }
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
     }
 }

--- a/src/ErrorProne.NET.CoreAnalyzers.Tests/CoreAnalyzers/DefaultEqualsOrHashCodeIsUsageAnalyzerTests.cs
+++ b/src/ErrorProne.NET.CoreAnalyzers.Tests/CoreAnalyzers/DefaultEqualsOrHashCodeIsUsageAnalyzerTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using ErrorProne.NET.TestHelpers;
 using NUnit.Framework;
 using VerifyCS = ErrorProne.NET.TestHelpers.CSharpCodeFixVerifier<
     ErrorProne.NET.CoreAnalyzers.DefaultEqualsOrHashCodeUsageAnalyzer,
@@ -14,10 +13,7 @@ namespace ErrorProne.NET.CoreAnalyzers.Tests.CoreAnalyzers
         [TestCaseSource(nameof(GetHasDiagnosticCases))]
         public async Task HasDiagnosticCases(string code)
         {
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
 
         public static IEnumerable<string> GetHasDiagnosticCases()

--- a/src/ErrorProne.NET.CoreAnalyzers.Tests/CoreAnalyzers/HashTableIncompatibilityAnalyzerTests.cs
+++ b/src/ErrorProne.NET.CoreAnalyzers.Tests/CoreAnalyzers/HashTableIncompatibilityAnalyzerTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using ErrorProne.NET.TestHelpers;
 using NUnit.Framework;
 using VerifyCS = ErrorProne.NET.TestHelpers.CSharpCodeFixVerifier<
     ErrorProne.NET.CoreAnalyzers.HashTableIncompatibilityAnalyzer,
@@ -19,13 +18,7 @@ struct MyStruct {}
 static class Ex {
     private static [|System.Collections.Generic.ISet<MyStruct>|] hs = null;
 }";
-            await new VerifyCS.Test
-            {
-                TestState =
-                {
-                    Sources = { code },
-                },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
 
         [Test]
@@ -36,22 +29,13 @@ struct MyStruct {}
 static class Ex {
     private static [|System.Collections.Generic.HashSet<MyStruct>|] P() => null;
 }";
-            await new VerifyCS.Test
-            {
-                TestState =
-                {
-                    Sources = { code },
-                },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code); ;
         }
 
         [TestCaseSource(nameof(GetHasDiagnosticCases))]
         public async Task HasDiagnosticCases(string code)
         {
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
 
         public static IEnumerable<string> GetHasDiagnosticCases()
@@ -101,7 +85,7 @@ struct MyStruct {}
 abstract class Ex : [|System.Collections.Generic.HashSet<MyStruct>|] {
 }";
             
-            // Implicitely typed local declaration
+            // Implicitly typed local declaration
             yield return @"
 struct MyStruct {}
 class Ex {

--- a/src/ErrorProne.NET.CoreAnalyzers.Tests/CoreAnalyzers/SetContainsAnalyzerTests.cs
+++ b/src/ErrorProne.NET.CoreAnalyzers.Tests/CoreAnalyzers/SetContainsAnalyzerTests.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using VerifyCS = ErrorProne.NET.TestHelpers.CSharpCodeFixVerifier<
     ErrorProne.NET.CoreAnalyzers.SetContainsAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
-using ErrorProne.NET.TestHelpers;
 
 namespace ErrorProne.NET.CoreAnalyzers.Tests.AsyncAnalyzers
 {
@@ -27,10 +26,7 @@ public class MyClass
 
 }";
 
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } }
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
         
         [Test]
@@ -49,10 +45,7 @@ public class MyClass
 
 }";
 
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } }
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
         
         [Test]
@@ -71,10 +64,7 @@ public class MyClass
 
 }";
 
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } }
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
         
         [Test]
@@ -94,10 +84,7 @@ public class MyClass
 
 }";
 
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } }
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
         
         [Test]
@@ -117,10 +104,7 @@ public class MyClass
 
 }";
 
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } }
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
         
         [Test]
@@ -140,10 +124,7 @@ public class MyClass
     }
 }";
 
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } }
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
         
         [Test]
@@ -163,10 +144,7 @@ public class MyClass
 
 }";
 
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } }
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
         
         [Test]
@@ -306,10 +284,7 @@ public class MyClass
 
 }";
 
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } }
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
     }
 }

--- a/src/ErrorProne.NET.CoreAnalyzers.Tests/CoreAnalyzers/SuspiciousExceptionHandling/OnlyMessageIsUsedTests.cs
+++ b/src/ErrorProne.NET.CoreAnalyzers.Tests/CoreAnalyzers/SuspiciousExceptionHandling/OnlyMessageIsUsedTests.cs
@@ -1,6 +1,4 @@
-﻿using ErrorProne.NET.TestHelpers;
-using Microsoft.CodeAnalysis;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System.Threading.Tasks;
 using VerifyCS = ErrorProne.NET.TestHelpers.CSharpCodeFixVerifier<
     ErrorProne.NET.CoreAnalyzers.SuspiciousExceptionHandlingAnalyzer,
@@ -18,21 +16,11 @@ namespace ErrorProne.NET.CoreAnalyzers.Tests.SuspiciousExceptionHandling
 class FooBar {
   public static void Foo() {
     try { new object(); }
-    catch(System.Exception e) {System.Console.WriteLine(e.Message);}
+    catch(System.Exception e) {System.Console.WriteLine(e.[|Message|]);}
   }
 }
 ";
-            await new VerifyCS.Test
-            {
-                TestState =
-                {
-                    Sources = { code },
-                    ExpectedDiagnostics =
-                    {
-                        VerifyCS.Diagnostic(SuspiciousExceptionHandlingAnalyzer.Rule).WithSpan(5, 59, 5, 66).WithArguments("e"),
-                    },
-                },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
 
         [Test]
@@ -42,21 +30,11 @@ class FooBar {
 class FooBar {
   public static void Foo() {
     try { new object(); }
-    catch(System.AggregateException e) {System.Console.WriteLine(e.Message);}
+    catch(System.AggregateException e) {System.Console.WriteLine(e.[|Message|]);}
   }
 }
 ";
-            await new VerifyCS.Test
-            {
-                TestState =
-                {
-                    Sources = { code },
-                    ExpectedDiagnostics =
-                    {
-                        VerifyCS.Diagnostic(SuspiciousExceptionHandlingAnalyzer.Rule).WithSpan(5, 68, 5, 75).WithArguments("e"),
-                    },
-                },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
 
         [Test]
@@ -66,21 +44,11 @@ class FooBar {
 class FooBar {
   public static void Foo() {
     try { new object(); }
-    catch(System.Reflection.TargetInvocationException e) {System.Console.WriteLine(e.Message);}
+    catch(System.Reflection.TargetInvocationException e) {System.Console.WriteLine(e.[|Message|]);}
   }
 }
 ";
-            await new VerifyCS.Test
-            {
-                TestState =
-                {
-                    Sources = { code },
-                    ExpectedDiagnostics =
-                    {
-                        VerifyCS.Diagnostic(SuspiciousExceptionHandlingAnalyzer.Rule).WithSpan(5, 86, 5, 93).WithArguments("e"),
-                    },
-                },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
 
         [Test]
@@ -90,21 +58,11 @@ class FooBar {
 class FooBar {
   public static void Foo() {
     try { new object(); }
-    catch(System.TypeLoadException e) {System.Console.WriteLine(e.Message);}
+    catch(System.TypeLoadException e) {System.Console.WriteLine(e.[|Message|]);}
   }
 }
 ";
-            await new VerifyCS.Test
-            {
-                TestState =
-                {
-                    Sources = { code },
-                    ExpectedDiagnostics =
-                    {
-                        VerifyCS.Diagnostic(SuspiciousExceptionHandlingAnalyzer.Rule).WithSpan(5, 67, 5, 74).WithArguments("e"),
-                    },
-                },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
         [Test]
         public async Task Warn_On_Anonymous_Usage_Of_ExceptionMessage()
@@ -118,23 +76,14 @@ class Test
       var errors=new ArrayList();
       try { new object();
       } catch (Exception exception) {
-        errors.Add($""{new { key, subKey, exception.Message }}"");
+        errors.Add($""{new { key, subKey, exception.[|Message|] }}"");
       }
     return errors;
     }
 }";
-            await new VerifyCS.Test
-            {
-                TestState =
-                {
-                    Sources = { code },
-                    ExpectedDiagnostics =
-                    {
-                        VerifyCS.Diagnostic(SuspiciousExceptionHandlingAnalyzer.Rule).WithSpan(10, 52, 10, 59).WithArguments("exception"),
-                    },
-                },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
+
         [Test]
         public async Task NoWarn_When_Only_Message_Is_Used_But_Exception_Is_Not_Generic()
         {

--- a/src/ErrorProne.NET.CoreAnalyzers.Tests/CoreAnalyzers/SuspiciousExceptionHandling/RemoveExMessageCodeFixProviderTests.cs
+++ b/src/ErrorProne.NET.CoreAnalyzers.Tests/CoreAnalyzers/SuspiciousExceptionHandling/RemoveExMessageCodeFixProviderTests.cs
@@ -1,6 +1,4 @@
-﻿using ErrorProne.NET.TestHelpers;
-using Microsoft.CodeAnalysis;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System.Threading.Tasks;
 using VerifyCS = ErrorProne.NET.TestHelpers.CSharpCodeFixVerifier<
     ErrorProne.NET.CoreAnalyzers.SuspiciousExceptionHandlingAnalyzer,
@@ -18,7 +16,7 @@ namespace ErrorProne.NET.CoreAnalyzers.Tests.SuspiciousExceptionHandling
 class FooBar {
   public static void Foo() {
     try { new object(); }
-    catch(System.Exception e) {System.Console.WriteLine(e.Message);}
+    catch(System.Exception e) {System.Console.WriteLine(e.[|Message|]);}
   }
 }";
 
@@ -30,21 +28,7 @@ class FooBar {
   }
 }";
 
-            await new VerifyCS.Test
-            {
-                TestState =
-                {
-                    Sources = { code },
-                    ExpectedDiagnostics =
-                    {
-                        VerifyCS.Diagnostic(SuspiciousExceptionHandlingAnalyzer.Rule).WithSpan(5, 59, 5, 66).WithArguments("e"),
-                    },
-                },
-                FixedState =
-                {
-                    Sources = { expected },
-                },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyCodeFixAsync(code, expected);
         }
     }
 }

--- a/src/ErrorProne.NET.CoreAnalyzers.Tests/CoreAnalyzers/SuspiciousExceptionHandling/SwallowAllExceptionsAnalyzer.cs
+++ b/src/ErrorProne.NET.CoreAnalyzers.Tests/CoreAnalyzers/SuspiciousExceptionHandling/SwallowAllExceptionsAnalyzer.cs
@@ -4,7 +4,6 @@
 //  
 // --------------------------------------------------------------------
 
-using ErrorProne.NET.TestHelpers;
 using NUnit.Framework;
 using System.Threading.Tasks;
 using VerifyCS = ErrorProne.NET.TestHelpers.CSharpCodeFixVerifier<
@@ -28,14 +27,8 @@ class Test
     catch {[|}|]
   }
 }";
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
-
-
-
 
         [Test]
         public async Task DoNotWarnOnAnonymousUsageOfException()
@@ -101,10 +94,7 @@ class Test
     return null;
   }
 }";
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
 
         [Test]
@@ -120,10 +110,7 @@ class Test
     catch {Console.WriteLine(42);[|}|]
   }
 }";
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
 
         [Test]
@@ -139,10 +126,7 @@ class Test
     catch(Exception) {Console.WriteLine(42);[|}|]
   }
 }";
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
 
         [Test]
@@ -158,13 +142,7 @@ class Test
     catch {Console.WriteLine(); if (n == 42) [|return;|] throw;}
   }
 }";
-            await new VerifyCS.Test
-            {
-                TestState =
-                {
-                    Sources = { code },
-                },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
 
         [Test]
@@ -180,13 +158,7 @@ class Test
     catch(Exception e) {if (e is System.AggregateException) throw;[|}|]
   }
 }";
-            await new VerifyCS.Test
-            {
-                TestState =
-                {
-                    Sources = { code },
-                },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
 
         [Test]
@@ -202,10 +174,7 @@ class Test
     catch(Exception e) {if (n != 0) throw; Console.WriteLine(42);[|}|]
   }
 }";
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
 
         [Test]

--- a/src/ErrorProne.NET.CoreAnalyzers.Tests/CoreAnalyzers/SuspiciousExceptionHandling/ThrowExAnalyzerTests.cs
+++ b/src/ErrorProne.NET.CoreAnalyzers.Tests/CoreAnalyzers/SuspiciousExceptionHandling/ThrowExAnalyzerTests.cs
@@ -4,7 +4,6 @@
 //  
 // --------------------------------------------------------------------
 
-using ErrorProne.NET.TestHelpers;
 using NUnit.Framework;
 using System.Threading.Tasks;
 using VerifyCS = ErrorProne.NET.TestHelpers.CSharpCodeFixVerifier<
@@ -67,13 +66,7 @@ class Test
   }
 }";
 
-            await new VerifyCS.Test
-            {
-                TestState =
-                {
-                    Sources = { test },
-                },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(test);
         }
 
         [Test]
@@ -90,13 +83,7 @@ class Test
   }
 }";
 
-            await new VerifyCS.Test
-            {
-                TestState =
-                {
-                    Sources = { test },
-                },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(test);
         }
 
         [Test]
@@ -124,12 +111,8 @@ class Test
     }
 }";
 
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { test } },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(test);
         }
-
 
         [Test]
         public async Task TestTwoWarnings()
@@ -148,10 +131,7 @@ class Test
     }
 }";
 
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { test } },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(test);
         }
     }
 }

--- a/src/ErrorProne.NET.CoreAnalyzers.Tests/CoreAnalyzers/UnobservedResultAnalyzerTests.cs
+++ b/src/ErrorProne.NET.CoreAnalyzers.Tests/CoreAnalyzers/UnobservedResultAnalyzerTests.cs
@@ -1,5 +1,4 @@
-﻿using ErrorProne.NET.TestHelpers;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System.Threading.Tasks;
 using VerifyCS = ErrorProne.NET.TestHelpers.CSharpCodeFixVerifier<
     ErrorProne.NET.CoreAnalyzers.UnobservedResultAnalyzer,
@@ -24,10 +23,7 @@ class FooBar
     }
 }
 ";
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } }
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
 
         [Test]
@@ -46,10 +42,7 @@ class FooBar
     }
 }
 ";
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } }
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
 
         [Test]
@@ -147,10 +140,7 @@ class FooBar
     }
 }
 ";
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } }
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
 
         [Test]
@@ -169,10 +159,7 @@ class FooBar
     }
 }
 ";
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } }
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
 
         [Test]
@@ -191,10 +178,7 @@ class FooBar
     }
 }
 ";
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } }
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
 
         [Test]
@@ -213,10 +197,7 @@ class FooBar
     }
 }
 ";
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } }
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
 
         [Test]
@@ -236,10 +217,7 @@ class FooBar
     }
 }
 ";
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } }
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
 
         [Test]
@@ -258,10 +236,7 @@ class FooBar
     }
 }
 ";
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } }
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
 
         [Test]

--- a/src/ErrorProne.NET.CoreAnalyzers/ConcurrencyAnalyzers/ConcurrentCollectionAnalyzer.cs
+++ b/src/ErrorProne.NET.CoreAnalyzers/ConcurrencyAnalyzers/ConcurrentCollectionAnalyzer.cs
@@ -5,8 +5,6 @@ using System.Linq;
 using ErrorProne.NET.Core;
 using ErrorProne.NET.CoreAnalyzers;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
 

--- a/src/ErrorProne.NET.CoreAnalyzers/CoreAnalyzers/ExceptionHandlingHelpers.cs
+++ b/src/ErrorProne.NET.CoreAnalyzers/CoreAnalyzers/ExceptionHandlingHelpers.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics.ContractsLight;
 using System.Linq;
 using System.Reflection;
 using ErrorProne.NET.Core;

--- a/src/ErrorProne.NET.CoreAnalyzers/DiagnosticDescriptors.cs
+++ b/src/ErrorProne.NET.CoreAnalyzers/DiagnosticDescriptors.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections.Immutable;
-using System.Linq;
-using ErrorProne.NET.CoreAnalyzers;
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 
 namespace ErrorProne.NET
 {

--- a/src/ErrorProne.NET.CoreAnalyzers/ExceptionsAnalyzers/PreconditionsBlock.cs
+++ b/src/ErrorProne.NET.CoreAnalyzers/ExceptionsAnalyzers/PreconditionsBlock.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.ContractsLight;
 using System.Linq;

--- a/src/ErrorProne.NET.CoreAnalyzers/ExceptionsAnalyzers/ThrowExAnalyzer.cs
+++ b/src/ErrorProne.NET.CoreAnalyzers/ExceptionsAnalyzers/ThrowExAnalyzer.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Immutable;
 using System.Linq;
 using ErrorProne.NET.Core;
-using ErrorProne.NET.CoreAnalyzers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/src/ErrorProne.NET.StructAnalyzers.Tests/ExplicitInParameterTests.cs
+++ b/src/ErrorProne.NET.StructAnalyzers.Tests/ExplicitInParameterTests.cs
@@ -1,7 +1,6 @@
 ﻿using NUnit.Framework;
 using ErrorProne.NET.TestHelpers;
 using System.Threading.Tasks;
-using Microsoft;
 using VerifyCS = ErrorProne.NET.TestHelpers.CSharpCodeFixVerifier<
     ErrorProne.NET.StructAnalyzers.ExplicitInParameterAnalyzer,
     ErrorProne.NET.StructAnalyzers.ExplicitInParameterCodeFixProvider>;

--- a/src/ErrorProne.NET.StructAnalyzers.Tests/HiddenStructCopyAnalyzerTests.cs
+++ b/src/ErrorProne.NET.StructAnalyzers.Tests/HiddenStructCopyAnalyzerTests.cs
@@ -1,5 +1,4 @@
-﻿using ErrorProne.NET.TestHelpers;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using VerifyCS = ErrorProne.NET.TestHelpers.CSharpCodeFixVerifier<
@@ -267,20 +266,14 @@ class Foo {
         public async Task HasDiagnosticsForMethodCallsOnReadOnlyField()
         {
             string code = @"struct S {private readonly long l1,l2,l3; public int Foo() => 42;} class Foo {private readonly S _s; public string Bar() => _s.[|Foo|]().ToString();}";
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
 
         [Test]
         public async Task HasDiagnosticsForMethodCallsOnInParameter()
         {
             string code = @"struct S {private readonly long l1,l2,l3; public int Foo() => 42;} class Foo {public int Bar(in S s) => s.[|Foo|]();}";
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
 
         [Test]
@@ -295,10 +288,7 @@ class Foo {
         return rs.[|Foo|]();
     }
 }";
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
 
         [Test]
@@ -313,10 +303,7 @@ public class C {
     private readonly S _s;
     public string M() => [|_s|][0];
 }"; ;
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
 
         [Test]
@@ -333,10 +320,7 @@ readonly struct S {
 static class C {
     public static void Foo(this S s) {}
 }"; ;
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
 
         [Test]
@@ -433,10 +417,7 @@ class Foo {private readonly S _s; public string Bar() => _s.ToString();}";
         [TestCaseSource(nameof(GetHasDiagnosticCases))]
         public async Task HasDiagnosticCases(string code)
         {
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
 
         public static IEnumerable<string> GetHasDiagnosticCases()

--- a/src/ErrorProne.NET.StructAnalyzers.Tests/MakeStructMemberReadOnlyAnalyzerTests.cs
+++ b/src/ErrorProne.NET.StructAnalyzers.Tests/MakeStructMemberReadOnlyAnalyzerTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using NUnit.Framework;
 using System.Threading.Tasks;
 using VerifyCS = ErrorProne.NET.TestHelpers.CSharpCodeFixVerifier<

--- a/src/ErrorProne.NET.StructAnalyzers.Tests/MakeStructMemberReadOnlyCodeFixProviderTests.cs
+++ b/src/ErrorProne.NET.StructAnalyzers.Tests/MakeStructMemberReadOnlyCodeFixProviderTests.cs
@@ -63,11 +63,7 @@ struct Test : ITest {
     readonly int ITest.Y => 42;
 }";
 
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } },
-                FixedState = { Sources = { expected } },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyCodeFixAsync(code, expected);
         }
 
         [Test]
@@ -83,11 +79,7 @@ struct Test : ITest {
     public readonly int X { get=> 42; }
 }";
 
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } },
-                FixedState = { Sources = { expected } },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyCodeFixAsync(code, expected);
         }
         
         [Test]
@@ -103,11 +95,7 @@ struct Test : ITest {
     public readonly int X() => 42;
 }";
 
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } },
-                FixedState = { Sources = { expected } },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyCodeFixAsync(code, expected);
         }
         
         [Test]
@@ -123,11 +111,7 @@ struct Test : ITest {
     public readonly int X() { return 42; }
 }";
 
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } },
-                FixedState = { Sources = { expected } },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyCodeFixAsync(code, expected);
         }
         
         [Test]
@@ -143,11 +127,7 @@ struct Test : ITest {
     public override readonly string ToString() => string.Empty;
 }";
 
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } },
-                FixedState = { Sources = { expected } },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyCodeFixAsync(code, expected);
         }
     }
 }

--- a/src/ErrorProne.NET.StructAnalyzers.Tests/MakeStructReadOnlyAnalyzerTests.cs
+++ b/src/ErrorProne.NET.StructAnalyzers.Tests/MakeStructReadOnlyAnalyzerTests.cs
@@ -110,10 +110,7 @@ this = other;
                 ref readonly SelfAssign x = ref this;
             }
         }";
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
         
         [Test]
@@ -148,29 +145,20 @@ this = other;
             public void Bar(in SelfAssign sa) {}
         }";
 
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
 
         [Test]
         public async Task HasDiagnosticsForEmptyStruct()
         {
             string code = @"struct [|FooBar|] {}";
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
 
         [TestCaseSource(nameof(GetHasDiagnosticCases))]
         public async Task HasDiagnosticCases(string code)
         {
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
 
         public static IEnumerable<string> GetHasDiagnosticCases()

--- a/src/ErrorProne.NET.StructAnalyzers.Tests/MakeStructReadOnlyCodeFixProviderTests.cs
+++ b/src/ErrorProne.NET.StructAnalyzers.Tests/MakeStructReadOnlyCodeFixProviderTests.cs
@@ -1,5 +1,4 @@
-﻿using ErrorProne.NET.TestHelpers;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System.Threading.Tasks;
 using VerifyCS = ErrorProne.NET.TestHelpers.CSharpCodeFixVerifier<
     ErrorProne.NET.StructAnalyzers.MakeStructReadOnlyAnalyzer,
@@ -17,11 +16,7 @@ namespace ErrorProne.NET.StructAnalyzers.Tests
 
             string expected = @"readonly struct FooBar {}";
 
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } },
-                FixedState = { Sources = { expected } },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyCodeFixAsync(code, expected);
         }
 
         [Test]
@@ -31,11 +26,7 @@ namespace ErrorProne.NET.StructAnalyzers.Tests
 
             string expected = @"internal readonly partial struct FooBar {}";
 
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } },
-                FixedState = { Sources = { expected } },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyCodeFixAsync(code, expected);
         }
 
         [Test]
@@ -45,11 +36,7 @@ namespace ErrorProne.NET.StructAnalyzers.Tests
 
             string expected = @"public readonly struct FooBar {}";
 
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } },
-                FixedState = { Sources = { expected } },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyCodeFixAsync(code, expected);
         }
 
         [Test]
@@ -65,11 +52,7 @@ public struct [|FooBar|] {}";
 /// </summary>
 public readonly struct FooBar {}";
 
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } },
-                FixedState = { Sources = { expected } },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyCodeFixAsync(code, expected);
         }
 
         [Test]
@@ -79,11 +62,7 @@ public readonly struct FooBar {}";
 
             string expected = @"public readonly partial struct FooBar {}";
 
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } },
-                FixedState = { Sources = { expected } },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyCodeFixAsync(code, expected);
         }
     }
 }

--- a/src/ErrorProne.NET.StructAnalyzers.Tests/StructSizeCalculatorIntegrationTests.cs
+++ b/src/ErrorProne.NET.StructAnalyzers.Tests/StructSizeCalculatorIntegrationTests.cs
@@ -93,7 +93,6 @@ class Foo {
    public static void Bar([|S s|]) {}
 }";
 
-
             await new VerifyCS.Test
                 {
                     TestState = { Sources = { code } },

--- a/src/ErrorProne.NET.StructAnalyzers.Tests/UseInModifierForReadOnlyStructAnalyzerTests.cs
+++ b/src/ErrorProne.NET.StructAnalyzers.Tests/UseInModifierForReadOnlyStructAnalyzerTests.cs
@@ -1,5 +1,4 @@
-﻿using ErrorProne.NET.TestHelpers;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using VerifyCS = ErrorProne.NET.TestHelpers.CSharpCodeFixVerifier<
@@ -22,10 +21,7 @@ namespace ErrorProne.NET.StructAnalyzers.Tests
         {
             string code = @"readonly struct S {readonly long l, l2,l3;} class FooBar { public void Foo([|S? n|]) {} }";
 
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
         
         [Test]
@@ -115,11 +111,7 @@ namespace ErrorProne.NET.StructAnalyzers.Tests
         public async Task HasDiagnosticsForLargeReadOnlyStruct()
         {
             string code = @"readonly struct S {readonly long l, l2,l3;} class FooBar { public void Foo([|S n|]) {} }";
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } },
-                ExpectedDiagnostics = { }
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
         
         [Test]
@@ -129,11 +121,7 @@ namespace ErrorProne.NET.StructAnalyzers.Tests
             // For indexers, the error is just on the parameter name itself!
             string code = @"readonly struct FooBar { readonly (long, long, long) data; }
         class FooClass { public int this[FooBar [|fb|]] => 42; }";
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } },
-                ExpectedDiagnostics = { }
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
 
         [Test]
@@ -158,19 +146,13 @@ class FooBar
     {
     }
 }";
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
 
         [TestCaseSource(nameof(GetHasDiagnosticsTestCases))]
         public async Task HasDiagnosticsTestCases(string code)
         {
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyAsync(code);
         }
 
         public static IEnumerable<string> GetHasDiagnosticsTestCases()

--- a/src/ErrorProne.NET.StructAnalyzers.Tests/UseInModifierForReadOnlyStructCodeFixProviderTests.cs
+++ b/src/ErrorProne.NET.StructAnalyzers.Tests/UseInModifierForReadOnlyStructCodeFixProviderTests.cs
@@ -1,6 +1,5 @@
 ﻿using ErrorProne.NET.TestHelpers;
 using NUnit.Framework;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using VerifyCS = ErrorProne.NET.TestHelpers.CSharpCodeFixVerifier<
     ErrorProne.NET.StructAnalyzers.UseInModifierForReadOnlyStructAnalyzer,
@@ -18,11 +17,7 @@ namespace ErrorProne.NET.StructAnalyzers.Tests
 
             string expected = @"readonly struct FooBar { public static void Foo(in FooBar fb) {} readonly (long, long, long) data; }";
 
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } },
-                FixedState = { Sources = { expected } },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyCodeFixAsync(code, expected);
         }
 
         [Test]
@@ -48,11 +43,7 @@ namespace ErrorProne.NET.StructAnalyzers.Tests
     readonly (long, long, long) data;
 }";
 
-            await new VerifyCS.Test
-            {
-                TestState = { Sources = { code } },
-                FixedState = { Sources = { expected } },
-            }.WithoutGeneratedCodeVerification().RunAsync();
+            await VerifyCS.VerifyCodeFixAsync(code, expected);
         }
 
         [Test]

--- a/src/ErrorProne.NET.StructAnalyzers/ErrorProne.NET.StructAnalyzers.csproj
+++ b/src/ErrorProne.NET.StructAnalyzers/ErrorProne.NET.StructAnalyzers.csproj
@@ -4,6 +4,25 @@
     <AssemblyName>ErrorProne.Net.StructAnalyzers</AssemblyName>
     <RootNamespace>ErrorProne.Net.StructAnalyzers</RootNamespace>
   </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\ErrorProne.NET.Core\AnalyzerConfigOptionsExtensions.cs" Link="AnalyzerConfigOptionsExtensions.cs" />
+    <Compile Include="..\ErrorProne.NET.Core\BodySyntaxExtensions.cs" Link="BodySyntaxExtensions.cs" />
+    <Compile Include="..\ErrorProne.NET.Core\CastUtilities.cs" Link="CastUtilities.cs" />
+    <Compile Include="..\ErrorProne.NET.Core\CompilationExtensions.cs" Link="CompilationExtensions.cs" />
+    <Compile Include="..\ErrorProne.NET.Core\DiagnosticAnalyzerBase.cs" Link="DiagnosticAnalyzerBase.cs" />
+    <Compile Include="..\ErrorProne.NET.Core\ErrorProneAttributes.cs" Link="ErrorProneAttributes.cs" />
+    <Compile Include="..\ErrorProne.NET.Core\FlowAnalysisExtensions.cs" Link="FlowAnalysisExtensions.cs" />
+    <Compile Include="..\ErrorProne.NET.Core\MethodDeclarationSyntaxExtensions.cs" Link="MethodDeclarationSyntaxExtensions.cs" />
+    <Compile Include="..\ErrorProne.NET.Core\NamedSymbolExtensions.cs" Link="NamedSymbolExtensions.cs" />
+    <Compile Include="..\ErrorProne.NET.Core\StructSizeCalculator.cs" Link="StructSizeCalculator.cs" />
+    <Compile Include="..\ErrorProne.NET.Core\SymbolAnalysisContextExtensions.cs" Link="SymbolAnalysisContextExtensions.cs" />
+    <Compile Include="..\ErrorProne.NET.Core\SymbolExtensions.cs" Link="SymbolExtensions.cs" />
+    <Compile Include="..\ErrorProne.NET.Core\SyntaxFactoryExtensions.cs" Link="SyntaxFactoryExtensions.cs" />
+    <Compile Include="..\ErrorProne.NET.Core\SyntaxNodeExtensions.cs" Link="SyntaxNodeExtensions.cs" />
+    <Compile Include="..\ErrorProne.NET.Core\TypeExtensions.cs" Link="TypeExtensions.cs" />
+    <Compile Include="..\ErrorProne.NET.Core\ValueTypeEqualityImplementations.cs" Link="ValueTypeEqualityImplementations.cs" />
+    <Compile Include="..\ErrorProne.NET.Core\WellKnownTypesProvider.cs" Link="WellKnownTypesProvider.cs" />
+  </ItemGroup>
 
   <!--
       Instead of splitting the code into a separate dll, just reference it as the source code.
@@ -11,7 +30,6 @@
       incompatible changes on the "core" level
    -->
   <ItemGroup>
-    <Compile Include="..\ErrorProne.NET.Core\**.cs" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="4.6.0" />
   </ItemGroup>
 

--- a/src/ErrorProne.NET.StructAnalyzers/MakeStructMemberReadOnlyAnalyzer.cs
+++ b/src/ErrorProne.NET.StructAnalyzers/MakeStructMemberReadOnlyAnalyzer.cs
@@ -1,6 +1,4 @@
 ﻿using System.Collections.Immutable;
-using System.ComponentModel.Design.Serialization;
-using System.Globalization;
 using ErrorProne.NET.Core;
 using ErrorProne.NET.Extensions;
 using Microsoft.CodeAnalysis;

--- a/src/ErrorProne.NET.StructAnalyzers/NonDefaultableStructs/NonDefaultableStructAnalysis.cs
+++ b/src/ErrorProne.NET.StructAnalyzers/NonDefaultableStructs/NonDefaultableStructAnalysis.cs
@@ -2,8 +2,8 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using Microsoft.CodeAnalysis;
 using ErrorProne.NET.Core;
+using Microsoft.CodeAnalysis;
 
 namespace ErrorProne.Net.StructAnalyzers.NonDefaultStructs
 {

--- a/src/ErrorProne.NET.StructAnalyzers/NonDefaultableStructs/NonDefaultableStructAnalyzerBase.cs
+++ b/src/ErrorProne.NET.StructAnalyzers/NonDefaultableStructs/NonDefaultableStructAnalyzerBase.cs
@@ -1,8 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using ErrorProne.NET.Core;
 using ErrorProne.NET.CoreAnalyzers;
 using Microsoft.CodeAnalysis;
 

--- a/src/ErrorProne.NET.StructAnalyzers/NonDefaultableStructs/NonDefaultableStructDeclarationAnalyzer.cs
+++ b/src/ErrorProne.NET.StructAnalyzers/NonDefaultableStructs/NonDefaultableStructDeclarationAnalyzer.cs
@@ -1,6 +1,4 @@
-using System.Collections.Immutable;
 using System.Linq;
-using ErrorProne.NET.Core;
 using ErrorProne.NET.CoreAnalyzers;
 using ErrorProne.NET.StructAnalyzers;
 using Microsoft.CodeAnalysis;

--- a/src/ErrorProne.NET.StructAnalyzers/ReadOnlyAnalyzer.cs
+++ b/src/ErrorProne.NET.StructAnalyzers/ReadOnlyAnalyzer.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using ErrorProne.NET.Core;
 using ErrorProne.NET.Extensions;


### PR DESCRIPTION
In many cases the error location was hardcoded in tests which is not very refactoring friendly.

The PR moves to use `[|code|]` pattern.