### PR TITLE
Fix ILRepack failure to locate Microsoft.CodeAnalysis 4.8.0

### DIFF
--- a/src/ILRepack.targets
+++ b/src/ILRepack.targets
@@ -7,6 +7,7 @@
     <ItemGroup>
       <InputAssemblies Include="$(TargetPath)"/>
       <InputAssemblies Include="$(PkgRuntimeContracts)\lib\netstandard1.1\RuntimeContracts.dll" />
+      <LibraryPath Include="%(ReferencePathWithRefAssemblies.RelativeDir)" />
     </ItemGroup>
     <ItemGroup>
       <!-- Dot not internalize any types inside this assembly -->
@@ -18,6 +19,7 @@
     DebugInfo="true"
     Internalize="true"
     InputAssemblies="@(InputAssemblies)"
+    LibraryPath="@(LibraryPath)"
     OutputFile="$(TargetPath)"
     Parallel="true"
     LogFile="$(TargetDir)replacklog.txt"


### PR DESCRIPTION
Please see https://github.com/ravibpatel/ILRepack.Lib.MSBuild.Task/issues/26#issuecomment-2019496987, without this the ILRepack fails on a clean machine.