### PR TITLE
Add System.TimeSpan size detection

### DIFF
--- a/src/ErrorProne.NET.Core/TypeExtensions.cs
+++ b/src/ErrorProne.NET.Core/TypeExtensions.cs
@@ -97,7 +97,14 @@ namespace ErrorProne.NET.Core
                     size = sizeof(long);
                     break;
                 default:
-                    size = 0;
+                    if (type.Name == "TimeSpan" && type.ContainingNamespace?.ToDisplayString(SymbolDisplayFormat) == "System")
+                    {
+                        size = sizeof(long);
+                    }
+                    else
+                    {
+                        size = 0;
+                    }
                     break;
             }
 


### PR DESCRIPTION
Currently, the instances of `System.TimeSpan` are estimated to have a size of 4, this is because this type in a reference assembly has an integer dummy field. This added check fixes that issue.
