### PR TITLE
Add analyzer to warn on returning null for Task-like types

### DIFF
--- a/src/ErrorProne.NET.CoreAnalyzers.Tests/AsyncAnalyzers/DoNotReturnNullForTaskLikeAnalyzerTests.cs
+++ b/src/ErrorProne.NET.CoreAnalyzers.Tests/AsyncAnalyzers/DoNotReturnNullForTaskLikeAnalyzerTests.cs
@@ -1,0 +1,195 @@
+using System.Threading.Tasks;
+using NUnit.Framework;
+using VerifyCS = ErrorProne.NET.TestHelpers.CSharpCodeFixVerifier<
+    ErrorProne.NET.AsyncAnalyzers.DoNotReturnNullForTaskLikeAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+
+namespace ErrorProne.NET.CoreAnalyzers.Tests.AsyncAnalyzers
+{
+    [TestFixture]
+    public class DoNotReturnNullForTaskLikeAnalyzerTests
+    {
+        [Test]
+        public async Task Warn_When_Null_Is_Returned_For_Task()
+        {
+            string code = @"
+using System.Threading.Tasks;
+public class MyClass
+{
+    public Task Foo()
+    {
+        [|return null;|]
+    }
+}";
+            await VerifyCS.VerifyAsync(code);
+        }
+
+        [Test]
+        public async Task Warn_When_Null_Is_Returned_For_Task_Of_T()
+        {
+            string code = @"
+using System.Threading.Tasks;
+public class MyClass
+{
+    public Task<int> Foo()
+    {
+        [|return null;|]
+    }
+}";
+            await VerifyCS.VerifyAsync(code);
+        }
+
+        [Test]
+        public async Task Warn_When_Null_Is_Part_Of_Switch()
+        {
+            string code = @"
+using System.Threading.Tasks;
+public class MyClass
+{
+    Task FooBar(int x) => [|x switch { 1 => null, _ => Task.CompletedTask }|];
+}";
+            await VerifyCS.VerifyAsync(code);
+        }
+        
+        [Test]
+        public async Task Warn_When_Null_Is_Returned_For_Task_Of_T_Expression_Body()
+        {
+            string code = @"
+using System.Threading.Tasks;
+public class MyClass
+{
+    Task FooBar(int x) => [|x switch { 1 => null, _ => Task.CompletedTask }|];
+}";
+            await VerifyCS.VerifyAsync(code);
+        }
+
+        [Test]
+        public async Task Warn_When_Null_Is_Returned_For_Task_In_Local_Function()
+        {
+            string code = @"
+using System.Threading.Tasks;
+public class MyClass
+{
+    public void Foo()
+    {
+        Task Bar(bool f)
+        {
+            if (f)
+                [|return null;|]
+
+            return Task.CompletedTask;  
+        }
+    }
+}";
+            await VerifyCS.VerifyAsync(code);
+        }
+
+        [Test]
+        public async Task Warn_When_Null_Is_Returned_For_Task_In_Lambda()
+        {
+            string code = @"
+using System;
+using System.Threading.Tasks;
+public class MyClass
+{
+    public void Foo()
+    {
+        Func<Task> f = () => { [|return null;|] };
+    }
+}";
+            await VerifyCS.VerifyAsync(code);
+        }
+
+        [Test]
+        public async Task No_Warn_For_Return_In_Async_Task()
+        {
+            string code = @"
+using System.Threading.Tasks;
+public class MyClass
+{
+    public async Task Foo()
+    {
+        await Task.Yield();
+        return;
+    }
+}";
+            await VerifyCS.VerifyAsync(code);
+        }
+
+        [Test]
+        public async Task No_Warn_When_Nullability_Is_On()
+        {
+            string code = @"
+using System.Threading.Tasks;
+#nullable enable
+public class MyClass
+{
+    public Task Foo()
+    {
+        return null;
+    }
+}";
+            await VerifyCS.VerifyAsync(code);
+        }
+
+        [Test]
+        public async Task No_Warn_When_Default_Is_Returned_For_ValueTask()
+        {
+            string code = @"
+using System.Threading.Tasks;
+public class MyClass
+{
+    public ValueTask Foo()
+    {
+        return default;
+    }
+}";
+            await VerifyCS.VerifyAsync(code);
+        }
+
+        [Test]
+        public async Task No_Warn_When_Default_Is_Returned_For_ValueTask_Of_T()
+        {
+            string code = @"
+using System.Threading.Tasks;
+public class MyClass
+{
+    public ValueTask<int> Foo()
+    {
+        return default;
+    }
+}";
+            await VerifyCS.VerifyAsync(code);
+        }
+
+        [Test]
+        public async Task Warn_When_Default_Is_Returned_For_Task()
+        {
+            string code = @"
+using System.Threading.Tasks;
+public class MyClass
+{
+    public Task Foo()
+    {
+        [|return default;|]
+    }
+}";
+            await VerifyCS.VerifyAsync(code);
+        }
+
+        [Test]
+        public async Task Warn_When_Default_Is_Returned_For_Task_Of_T()
+        {
+            string code = @"
+using System.Threading.Tasks;
+public class MyClass
+{
+    public Task<int> Foo()
+    {
+        [|return default;|]
+    }
+}";
+            await VerifyCS.VerifyAsync(code);
+        }
+    }
+}

--- a/src/ErrorProne.NET.CoreAnalyzers/AnalyzerReleases.Unshipped.md
+++ b/src/ErrorProne.NET.CoreAnalyzers/AnalyzerReleases.Unshipped.md
@@ -22,6 +22,7 @@ EPC27 | CodeSmell | Warning | AsyncVoidMethodAnalyzer
 EPC28 | CodeSmell | Warning | ExcludeFromCodeCoverageOnPartialClassAnalyzer
 EPC29 | CodeSmell | Warning | ExcludeFromCodeCoverageMessageAnalyzer: Warn when ExcludeFromCodeCoverageAttribute is used without a message argument.
 EPC30 | CodeSmell | Warning | RecursiveCallAnalyzer: Warns when a method calls itself recursively (conditionally or unconditionally).
+EPC31 | CodeSmell | Warning | DoNotReturnNullForTaskLikeAnalyzer
 ERP021 | CodeSmell | Warning | ThrowExAnalyzer
 ERP022 | CodeSmell | Warning | SwallowAllExceptionsAnalyzer
 ERP031 | Concurrency | Warning | ConcurrentCollectionAnalyzer

--- a/src/ErrorProne.NET.CoreAnalyzers/AsyncAnalyzers/DoNotReturnNullForTaskLikeAnalyzer.cs
+++ b/src/ErrorProne.NET.CoreAnalyzers/AsyncAnalyzers/DoNotReturnNullForTaskLikeAnalyzer.cs
@@ -1,0 +1,156 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using ErrorProne.NET.Core;
+using Microsoft.CodeAnalysis.Operations;
+using ErrorProne.NET.CoreAnalyzers;
+
+namespace ErrorProne.NET.AsyncAnalyzers
+{
+    /// <summary>
+    /// Warns when a method that returns a Task-like type (Task, Task&lt;T&gt;, ValueTask, etc.) returns null.
+    /// The analyzer is useful only when non-nullable reference types are not enabled!
+    /// If they are enabled, the compiler will already warn about returning null for a non-nullable return type.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class DoNotReturnNullForTaskLikeAnalyzer : DiagnosticAnalyzerBase
+    {
+        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptors.EPC31;
+
+        /// <nodoc />
+        public DoNotReturnNullForTaskLikeAnalyzer()
+            : base(Rule)
+        {
+        }
+
+        /// <inheritdoc />
+        protected override void InitializeCore(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+            
+            context.RegisterOperationAction(AnalyzeReturnOperation, OperationKind.Return);
+        }
+
+        private void AnalyzeReturnOperation(OperationAnalysisContext context)
+        {
+            var returnOperation = (IReturnOperation)context.Operation;
+            
+            // In case of 'return;'
+            if (returnOperation.ReturnedValue == null)
+            {
+                return;
+            }
+
+            //var semanticModel = context.Compilation.GetSemanticModel(returnOperation.Syntax.SyntaxTree, false);
+            
+            
+
+            // We don't need to analyze the method (which might be expensive), but we can just check the type of the return value.
+            // And do nothing if it's not a Task-like type.
+            var returnType = returnOperation.ReturnedValue?.Type;
+            if (returnType == null || returnType.NullableAnnotation == NullableAnnotation.Annotated)
+            {
+                // Not running this analysis when nullable types are on.
+                // In this case, the compiler will emit a warning.
+                return;
+            }
+
+            if (returnType.IsTaskLike(context.Compilation) != true)
+            {
+                return;
+            }
+            
+            var returnedValueOperation = returnOperation.ReturnedValue;
+            IMethodSymbol? methodSymbol = findParentLocalOrLambdaSymbol(returnedValueOperation) ?? context.ContainingSymbol as IMethodSymbol;
+            if (methodSymbol is not null && !methodSymbol.IsAsync)
+            {
+                if (isReturningNull(returnedValueOperation, context.Compilation) && methodSymbol.ReturnType.IsTaskLike(context.Compilation))
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(Rule, returnOperation.Syntax.GetLocation(), methodSymbol.Name));
+                }
+            }
+
+            static bool isReturningNull(IOperation? operation, Compilation compilation)
+            {
+                if (operation == null)
+                {
+                    return false;
+                }
+
+                if (operation is IReturnOperation returnedValueOperation)
+                {
+                    // Case A: Check if the returned value is a constant null.
+                    if (returnedValueOperation.ConstantValue.HasValue && returnedValueOperation.ConstantValue.Value == null)
+                    {
+                        return true;
+                    }
+
+                    
+                }
+
+                // Case B: Check for the 'default' keyword used with a reference type.
+                // This handles 'return default;' where the method's return type is a class, interface, delegate, or array.
+                if (operation is IDefaultValueOperation &&
+                    operation.Type?.IsReferenceType == true)
+                {
+                    return true;
+                }
+
+                if (operation.ConstantValue.HasValue && operation.ConstantValue.Value is null)
+                {
+                    return true;
+                }
+
+                if (operation is IConversionOperation conversion)
+                {
+                    if (conversion.Type.IsTaskLike(compilation))
+                    {
+                        return false;
+                    }
+
+                    return isReturningNull(conversion.Operand, compilation);
+                }
+
+                if (operation is IConditionalAccessOperation conditionalAccess)
+                {
+                    return isReturningNull(conditionalAccess.Operation, compilation) || isReturningNull(conditionalAccess.WhenNotNull, compilation);
+                }
+                else if (operation is IConditionalOperation conditional)
+                {
+                    return isReturningNull(conditional.WhenTrue, compilation) || isReturningNull(conditional.WhenFalse, compilation);
+                }
+                else if (operation is ISwitchExpressionOperation switchExpression)
+                {
+                    foreach (var arm in switchExpression.Arms)
+                    {
+                        if (isReturningNull(arm.Value, compilation))
+                        {
+                            return true;
+                        }
+                    }
+                }
+
+                return false;
+
+            }
+
+            static IMethodSymbol? findParentLocalOrLambdaSymbol(IOperation operation)
+            {
+                foreach (var parent in operation.EnumerateParentOperations())
+                {
+                    if (parent is ILocalFunctionOperation lf)
+                    {
+                        return lf.Symbol;
+                    }
+
+                    if (parent is IAnonymousFunctionOperation f)
+                    {
+                        return f.Symbol;
+                    }
+                }
+
+                return null;
+            }
+        }
+    }
+}

--- a/src/ErrorProne.NET.CoreAnalyzers/CompilationExtensions.cs
+++ b/src/ErrorProne.NET.CoreAnalyzers/CompilationExtensions.cs
@@ -108,6 +108,18 @@ namespace ErrorProne.NET.Core
 
             return argumentOperation?.Type;
         }
+
+        public static IEnumerable<IOperation> EnumerateParentOperations(this IOperation? operation)
+        {
+            while (operation != null)
+            {
+                operation = operation.Parent;
+                if (operation != null)
+                {
+                    yield return operation;
+                }
+            }
+        }
     }
 
     

--- a/src/ErrorProne.NET.CoreAnalyzers/DiagnosticDescriptors.cs
+++ b/src/ErrorProne.NET.CoreAnalyzers/DiagnosticDescriptors.cs
@@ -185,6 +185,16 @@ namespace ErrorProne.NET
             description: "Detects when a method calls itself recursively, either conditionally or unconditionally.");
 
         /// <nodoc />
+        public static readonly DiagnosticDescriptor EPC31 = new DiagnosticDescriptor(
+            nameof(EPC31),
+            title: "Do not return null for Task-like types",
+            messageFormat: "Do not return null for Task-like type from method '{0}'",
+            category: CodeSmellCategory,
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: "Returning null for a Task-like type may lead to NullReferenceException when the task is awaited. Return Task.Completed task instead.");
+
+        /// <nodoc />
         public static readonly DiagnosticDescriptor ERP031 = new DiagnosticDescriptor(
             nameof(ERP031), 
             title: "The API is not thread-safe", 


### PR DESCRIPTION
Introduces DoNotReturnNullForTaskLikeAnalyzer (EPC31) to warn when methods returning Task, Task<T>, or similar types return null or default, which can cause runtime exceptions. Includes analyzer implementation, tests, diagnostic descriptor, and release notes update.