### PR TITLE
Release version 0.8.1 with minor fixes

### DIFF
--- a/src/ErrorProne.NET.CoreAnalyzers.CodeFixes/ErrorProne.NET.CoreAnalyzers.CodeFixes.csproj
+++ b/src/ErrorProne.NET.CoreAnalyzers.CodeFixes/ErrorProne.NET.CoreAnalyzers.CodeFixes.csproj
@@ -18,6 +18,9 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Description>Core .NET analyzers for detecting the most common coding issues</Description>
     <PackageReleaseNotes>
+      0.8.1
+        * Minor fixes in recursive analyzer
+        * Downgraded the compiler packages to 4.13.0 to avoid conflicts with the latest Roslyn versions.
       0.8.0
         * Add DoNotBlockAsyncCallsInAsyncMethodsAnalyzer
         * Add MustUseResultAnalyzer

--- a/src/version.json
+++ b/src/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.8.0-beta.{height}",
+  "version": "0.8.1-beta.{height}",
   "assemblyVersion": {
     "precision": "revision"
   },


### PR DESCRIPTION
Updated to version 0.8.1 with minor fixes in the recursive analyzer and downgraded compiler packages to 4.13.0 to avoid conflicts with the latest Roslyn versions.