### PR TITLE
EPC30: don't warn when same method is called from a nested function (…

### DIFF
--- a/src/ErrorProne.NET.CoreAnalyzers.Tests/RecursiveCallAnalyzerTests.cs
+++ b/src/ErrorProne.NET.CoreAnalyzers.Tests/RecursiveCallAnalyzerTests.cs
@@ -130,6 +130,52 @@ class C {
 ";
             await Verify.VerifyAsync(test);
         }
+
+        [Test]
+        public async Task NoWarn_When_Same_Method_Is_Called_From_Lambda()
+        {
+            // Issue #318: a call to the same method from within a lambda is not
+            // an unconditional recursive call -- the lambda body is deferred.
+            var test = @"
+using System;
+class C {
+    void Foo() {
+        Action a = () => Foo();
+        a();
+    }
+}
+";
+            await Verify.VerifyAsync(test);
+        }
+
+        [Test]
+        public async Task NoWarn_When_Same_Method_Is_Called_From_AnonymousMethod()
+        {
+            var test = @"
+using System;
+class C {
+    void Foo() {
+        Action a = delegate { Foo(); };
+        a();
+    }
+}
+";
+            await Verify.VerifyAsync(test);
+        }
+
+        [Test]
+        public async Task NoWarn_When_Same_Method_Is_Called_From_LocalFunction()
+        {
+            var test = @"
+class C {
+    void Foo() {
+        void Local() { Foo(); }
+        Local();
+    }
+}
+";
+            await Verify.VerifyAsync(test);
+        }
         
         [Test]
         public async Task NoWarn_For_Factorial()

--- a/src/ErrorProne.NET.CoreAnalyzers/RecursiveCallAnalyzer.cs
+++ b/src/ErrorProne.NET.CoreAnalyzers/RecursiveCallAnalyzer.cs
@@ -31,6 +31,13 @@ namespace ErrorProne.NET.CoreAnalyzers
             
             foreach (var invocation in methodBody.Descendants().OfType<IInvocationOperation>())
             {
+                // Calls inside a lambda or local function don't execute as part of this method's
+                // immediate control flow, so they aren't unconditional recursion. See issue #318.
+                if (IsInsideNestedFunction(invocation))
+                {
+                    continue;
+                }
+
                 // Check if all parameters are passed as-is
                 // So Factorial(n - 1) should be totally fine!
                 if (invocation.Arguments.Length == method.Parameters.Length &&
@@ -60,6 +67,19 @@ namespace ErrorProne.NET.CoreAnalyzers
                         method.Name));
                 }
             }
+        }
+
+        private static bool IsInsideNestedFunction(IOperation operation)
+        {
+            for (var parent = operation.Parent; parent != null; parent = parent.Parent)
+            {
+                if (parent is IAnonymousFunctionOperation or ILocalFunctionOperation)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private static bool HasTouchedRefParameterBeforeCall(IInvocationOperation recursiveCall, IMethodSymbol method, HashSet<IParameterSymbol> touchedRefParameters)


### PR DESCRIPTION
…#318)

RecursiveCallAnalyzer descended into the full method body, so calls to the containing method from inside a lambda, anonymous method, or local function were flagged as unconditional recursion. Those calls don't execute as part of the enclosing method's control flow, so skip invocations nested inside IAnonymousFunctionOperation / ILocalFunctionOperation.