### PR TITLE
Fix ERP042 false positive on properties

### DIFF
--- a/samples/ErrorProne.Samples/CoreAnalyzers/DemoEventSource.cs
+++ b/samples/ErrorProne.Samples/CoreAnalyzers/DemoEventSource.cs
@@ -32,4 +32,7 @@ public sealed class DemoEventSource : System.Diagnostics.Tracing.EventSource
     private int SomeValue { get; set; }
 
     private string Name { get; set; }
+
+    // Non-void returning methods are not implicit event methods (ERP042 must not warn here).
+    private int Compute() => 42;
 }

--- a/samples/ErrorProne.Samples/CoreAnalyzers/DemoEventSource.cs
+++ b/samples/ErrorProne.Samples/CoreAnalyzers/DemoEventSource.cs
@@ -28,4 +28,8 @@ public sealed class DemoEventSource : System.Diagnostics.Tracing.EventSource
         WriteEvent(5, str, 42);
     }
 
+    // Properties should NOT be treated as event methods (ERP042 must not warn here).
+    private int SomeValue { get; set; }
+
+    private string Name { get; set; }
 }

--- a/src/ErrorProne.NET.CoreAnalyzers.Tests/CoreAnalyzers/EventSourceAnalyzerTests.cs
+++ b/src/ErrorProne.NET.CoreAnalyzers.Tests/CoreAnalyzers/EventSourceAnalyzerTests.cs
@@ -96,6 +96,25 @@ public sealed class DemoEventSource : System.Diagnostics.Tracing.EventSource
         }
 
         [Test]
+        public async Task No_Warn_On_Non_Void_Method()
+        {
+            // Only void-returning methods are implicit event methods, so non-void methods must not be flagged.
+            string code = @"
+[System.Diagnostics.Tracing.EventSource(Name = ""Demo"")]
+public sealed class DemoEventSource : System.Diagnostics.Tracing.EventSource
+{
+    private int Compute() => 42;
+
+    private string GetName() { return string.Empty; }
+
+    [System.Diagnostics.Tracing.Event(1)]
+    public void AppStarted(string message) => WriteEvent(1, message);
+}";
+
+            await VerifyCS.VerifyAsync(code);
+        }
+
+        [Test]
         public async Task No_Warn_When_NonEvent_Method_Precedes_Implicit_Event()
         {
             // A [NonEvent] method must not shift the inferred ordinal id of the implicit event method.

--- a/src/ErrorProne.NET.CoreAnalyzers.Tests/CoreAnalyzers/EventSourceAnalyzerTests.cs
+++ b/src/ErrorProne.NET.CoreAnalyzers.Tests/CoreAnalyzers/EventSourceAnalyzerTests.cs
@@ -96,6 +96,25 @@ public sealed class DemoEventSource : System.Diagnostics.Tracing.EventSource
         }
 
         [Test]
+        public async Task No_Warn_When_NonEvent_Method_Precedes_Implicit_Event()
+        {
+            // A [NonEvent] method must not shift the inferred ordinal id of the implicit event method.
+            // Here the implicit event method is the 2nd ordinary method but the 1st actual event, so its id is 1
+            // and WriteEvent(1, ...) must match.
+            string code = @"
+[System.Diagnostics.Tracing.EventSource(Name = ""Demo"")]
+public sealed class DemoEventSource : System.Diagnostics.Tracing.EventSource
+{
+    [System.Diagnostics.Tracing.NonEvent]
+    public void Helper() {}
+
+    public void AppStarted(string message) => WriteEvent(1, message);
+}";
+
+            await VerifyCS.VerifyAsync(code);
+        }
+
+        [Test]
         public async Task No_Warn_On_Properties()
         {
             string code = @"

--- a/src/ErrorProne.NET.CoreAnalyzers.Tests/CoreAnalyzers/EventSourceAnalyzerTests.cs
+++ b/src/ErrorProne.NET.CoreAnalyzers.Tests/CoreAnalyzers/EventSourceAnalyzerTests.cs
@@ -96,6 +96,31 @@ public sealed class DemoEventSource : System.Diagnostics.Tracing.EventSource
         }
 
         [Test]
+        public async Task No_Warn_On_Properties()
+        {
+            string code = @"
+[System.Diagnostics.Tracing.EventSource(Name = ""Demo"")]
+public sealed class DemoEventSource : System.Diagnostics.Tracing.EventSource
+{
+    private int AutoProperty { get; set; }
+
+    private string ExpressionProperty => string.Empty;
+
+    private int _field;
+    private int FullProperty
+    {
+        get => _field;
+        set => _field = value;
+    }
+
+    [System.Diagnostics.Tracing.Event(1)]
+    public void AppStarted(string message) => WriteEvent(1, message);
+}";
+
+            await VerifyCS.VerifyAsync(code);
+        }
+
+        [Test]
         public async Task Warn_On_Count_Mismatch_Core()
         {
             string code = @"

--- a/src/ErrorProne.NET.CoreAnalyzers/EventSourceAnalysis/EventSourceAnalyzer.cs
+++ b/src/ErrorProne.NET.CoreAnalyzers/EventSourceAnalysis/EventSourceAnalyzer.cs
@@ -286,14 +286,15 @@ namespace ErrorProne.NET.EventSourceAnalysis
             if (eventAttribute == null)
             {
                 // From the docs: "Any instance, non-virtual, void returning method defined in an event source class is by default an ETW event method."
-                // Only ordinary methods can be event methods. Property/event accessors, operators, etc. must be ignored even
-                // though some of them (like property setters) are non-static, non-virtual and void-returning.
-                if (method.MethodKind == MethodKind.Ordinary && !method.IsStatic && !method.IsVirtual && method.ReturnsVoid && !method.IsConstructor() && method.MethodKind != MethodKind.Destructor)
+                if (IsImplicitEventMethodCandidate(method, compilation))
                 {
                     // In this case the Id is inferred.
                     // "Implicitly: by the ordinal number of the method in the class (thus the first method in the class is 1, second 2 …)"
-                    var methods = method.ContainingType.GetMembers().OfType<IMethodSymbol>().Where(m => m.MethodKind == MethodKind.Ordinary && !m.IsStatic && !m.IsVirtual && m.ReturnsVoid).ToList();
-                    
+                    // The ordinal list must use the same eligibility rules so that [NonEvent] (and other non-event) methods
+                    // don't shift the inferred index of real event methods.
+                    var methods = method.ContainingType.GetMembers().OfType<IMethodSymbol>()
+                        .Where(m => IsImplicitEventMethodCandidate(m, compilation)).ToList();
+
                     var index = methods.IndexOf(method) + 1;
                     return new EventMethodInfo(EventId: index, MethodSymbol: method);
                 }
@@ -314,6 +315,23 @@ namespace ErrorProne.NET.EventSourceAnalysis
             }
 
             return new EventMethodInfo(eventId, method);
+        }
+
+        /// <summary>
+        /// Returns true if the method can be an implicit ETW event method (i.e. one without an explicit 'Event' attribute).
+        /// </summary>
+        private static bool IsImplicitEventMethodCandidate(IMethodSymbol method, Compilation compilation)
+        {
+            // Only ordinary methods can be event methods. Property/event accessors, operators, constructors, destructors, etc.
+            // must be ignored even though some of them (like property setters) are non-static, non-virtual and void-returning.
+            // 'MethodKind.Ordinary' already excludes constructors and destructors.
+            if (method.MethodKind != MethodKind.Ordinary || method.IsStatic || method.IsVirtual || !method.ReturnsVoid)
+            {
+                return false;
+            }
+
+            // Methods marked with [NonEvent] are explicitly excluded from being events.
+            return !method.GetAttributes().Any(a => a.AttributeClass?.IsClrType(compilation, typeof(NonEventAttribute)) == true);
         }
 
         private static IOperation GetExpectedEventId(IInvocationOperation invocation)

--- a/src/ErrorProne.NET.CoreAnalyzers/EventSourceAnalysis/EventSourceAnalyzer.cs
+++ b/src/ErrorProne.NET.CoreAnalyzers/EventSourceAnalysis/EventSourceAnalyzer.cs
@@ -286,11 +286,13 @@ namespace ErrorProne.NET.EventSourceAnalysis
             if (eventAttribute == null)
             {
                 // From the docs: "Any instance, non-virtual, void returning method defined in an event source class is by default an ETW event method."
-                if (!method.IsStatic && !method.IsVirtual && method.ReturnsVoid && !method.IsConstructor() && method.MethodKind != MethodKind.Destructor)
+                // Only ordinary methods can be event methods. Property/event accessors, operators, etc. must be ignored even
+                // though some of them (like property setters) are non-static, non-virtual and void-returning.
+                if (method.MethodKind == MethodKind.Ordinary && !method.IsStatic && !method.IsVirtual && method.ReturnsVoid && !method.IsConstructor() && method.MethodKind != MethodKind.Destructor)
                 {
                     // In this case the Id is inferred.
                     // "Implicitly: by the ordinal number of the method in the class (thus the first method in the class is 1, second 2 …)"
-                    var methods = method.ContainingType.GetMembers().OfType<IMethodSymbol>().Where(m => !m.IsStatic && !m.IsVirtual && m.ReturnsVoid).ToList();
+                    var methods = method.ContainingType.GetMembers().OfType<IMethodSymbol>().Where(m => m.MethodKind == MethodKind.Ordinary && !m.IsStatic && !m.IsVirtual && m.ReturnsVoid).ToList();
                     
                     var index = methods.IndexOf(method) + 1;
                     return new EventMethodInfo(EventId: index, MethodSymbol: method);


### PR DESCRIPTION
## Problem

ERP042 (EventSource implementation correctness) emitted a warning that a private method "does not call WriteEvent" for **properties** declared in an `EventSource`-derived class.

## Root cause

In `EventSourceAnalyzer.TryGetEventMethod`, implicit event-method detection treated *any* non-static, non-virtual, void-returning method as an ETW event method. A property **setter** matches all of those criteria (it returns `void`), so properties were incorrectly flagged.

## Fix

Restrict implicit event-method detection to `MethodKind.Ordinary`, excluding property/event accessors, operators, etc. Applied to both the event-method check and the ordinal index computation used to infer event IDs.

## Testing

- Added `No_Warn_On_Properties` unit test covering auto-properties, expression-bodied properties, and full get/set properties alongside a valid event method.
- Extended the `DemoEventSource` sample with properties to manually reproduce the original false positive.
- All 18 EventSource analyzer tests pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>